### PR TITLE
feat: remove appclaener from homebrew

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -74,7 +74,6 @@
       "lulu"
       "zerotier-one"
       "stats"
-      "appcleaner"
       "keka"
       "obsidian"
 


### PR DESCRIPTION
Just figured that we can just uninstall programs via raycast.
