### PR TITLE
feat: update init script to include --verbose & --impure

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -36,6 +36,6 @@ echo "install-node-packages script executed successfully"
 
 # Run the nix command with the found directory and provided user
 echo "Building nix-darwin now..."
-nix run nix-darwin -- switch --flake "$config_dir#$user"
+nix run nix-darwin -- switch --verbose --impure --flake "$config_dir#$user"
 
 echo "Initialisation completed"


### PR DESCRIPTION
Needs the `--impure` flag to install `kanata`. The `--verbose` flag is
just personal preference.
