### PR TITLE
feat: remove and update neovim keymaps

### DIFF
--- a/config/nvim/lua/config/keymaps.lua
+++ b/config/nvim/lua/config/keymaps.lua
@@ -118,11 +118,11 @@ vim.keymap.set(
 -- vim.keymap.set({ "n", "v" }, "c", '"_c', { desc = "Change without replacing" })
 
 --- Find/replace for the word under the cursor
-vim.keymap.set("n", "<leader>r", function()
-	local cmd = ":%s/<C-r><C-w>/<C-r><C-w>/gI<Left><Left><Left>"
-	local keys = vim.api.nvim_replace_termcodes(cmd, true, false, true)
-	vim.api.nvim_feedkeys(keys, "n", false)
-end, { desc = "Replace word under cursor" })
+-- vim.keymap.set("n", "<leader>r", function()
+-- 	local cmd = ":%s/<C-r><C-w>/<C-r><C-w>/gI<Left><Left><Left>"
+-- 	local keys = vim.api.nvim_replace_termcodes(cmd, true, false, true)
+-- 	vim.api.nvim_feedkeys(keys, "n", false)
+-- end, { desc = "Replace word under cursor" })
 
 --- Move lines
 vim.keymap.set("v", "J", ":m '>+1<cr>gv=gv", { desc = "Move line up" })

--- a/config/nvim/lua/config/keymaps.lua
+++ b/config/nvim/lua/config/keymaps.lua
@@ -114,8 +114,8 @@ vim.keymap.set(
 	'"_x',
 	{ desc = "Delete a character without copying it" }
 )
-vim.keymap.set({ "n", "v" }, "d", '"_d', { desc = "Delete without replacing" })
-vim.keymap.set({ "n", "v" }, "c", '"_c', { desc = "Change without replacing" })
+-- vim.keymap.set({ "n", "v" }, "d", '"_d', { desc = "Delete without replacing" })
+-- vim.keymap.set({ "n", "v" }, "c", '"_c', { desc = "Change without replacing" })
 
 --- Find/replace for the word under the cursor
 vim.keymap.set("n", "<leader>r", function()


### PR DESCRIPTION
- **allow d and c to replace register, try to use paste history instead**
- **remove replace word under cursor, not really using it**
