### PR TITLE
fix: use alacritty from brew instead of nix

### DIFF
--- a/home/core.nix
+++ b/home/core.nix
@@ -23,7 +23,7 @@
     brave
 
     # --- terminal ---
-    alacritty
+    # alacritty
 
     # --- rust ---
     cargo

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -92,6 +92,8 @@
       "pronotes"
       "hammerspoon" # mainly used for safari vim mode
 
+      "alacritty"
+
       # --- docker desktop alternative ---
       "orbstack"
 


### PR DESCRIPTION
For whatever reason, only alacritty from brew able to run kanata
properly...
