### PR TITLE
fix: attach or create new session

### DIFF
--- a/scripts/tmux-sessionizer.sh
+++ b/scripts/tmux-sessionizer.sh
@@ -27,7 +27,7 @@ tmux_running=$(pgrep tmux)
 
 # If not in a tmux session and no tmux is running, create a new session
 if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
-    tmux new-session -s "$selected_name" -c "$selected"
+    tmux new-session -A -s "$selected_name" -c "$selected"
     exit 0
 fi
 


### PR DESCRIPTION
This is a better approach because of resurrection. If we don't add -A
flag, the first time during resurrection will always output 'session xx
already exists'
