### PR TITLE
feat(skills): add agent-skills-nix with 48+ skills across 6 sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,64 +3,112 @@
 ## Architecture
 
 ```
-flake.nix                 ← Entry point (flake-parts based)
-├── lib/                  ← Builder functions & flake-parts modules
-│   ├── default.nix       ← mkDarwinSystem, mkNixosSystem, mkHomeConfiguration
-│   ├── systems.nix       ← Supported system list
-│   ├── treefmt.nix       ← Code formatting config
-│   ├── pre-commit.nix    ← Git hooks
-│   └── devshell.nix      ← Development shell
-├── hosts/
-│   └── default.nix       ← Centralized host metadata (single source of truth)
+flake.nix                 ← Entry point (flake-parts)
+├── lib/default.nix       ← mkDarwinSystem, mkNixosSystem, mkHomeConfiguration
+├── hosts/default.nix     ← Per-host metadata (single source of truth)
 ├── modules/
-│   ├── darwin/           ← nix-darwin system modules
+│   ├── darwin/           ← macOS system modules
 │   ├── nixos/            ← NixOS system modules
-│   ├── home/             ← Home-manager modules
+│   ├── home/
 │   │   ├── base.nix      ← HM base (home dir, aliases, stateVersion)
 │   │   ├── profiles/     ← Feature profiles (import package groups)
-│   │   └── packages/     ← Individual program configs (one file per program)
-│   └── stylix/           ← Theming module
-├── pkgs/                 ← Custom packages & overrides
-├── profiles/             ← Per-host profiles
-│   ├── darwin/
-│   └── nixos/
-├── config/               ← Static dotfiles (symlinked, not managed by Nix)
-└── scripts/              ← Shell scripts
+│   │   └── packages/     ← One file per program
+│   └── stylix/           ← Theming
+├── pkgs/custom/          ← Custom derivations (fetchurl, fetchzip)
+├── profiles/
+│   ├── darwin/           ← Per-host darwin overrides
+│   └── nixos/            ← Per-host nixos overrides
+├── skills/               ← Local agent skills (SKILL.md per directory)
+├── config/               ← Static dotfiles (symlinked, not Nix-managed)
+└── scripts/              ← Shell utilities
 ```
 
-## Key Design Principles
+## How to add things
 
-1. **Data-driven hosts** — All per-host values in `hosts/default.nix`. Adding a new host means adding one entry there and one profile in `profiles/<type>/`.
-2. **No thin aggregation layers** — `modules/home/profiles/*.nix` group packages by category but with `imports = [...]`. No `lib.mkEnableOption` wrappers — just direct imports.
-3. **Proper Nix module system** — All darwin/NixOS modules use standard module args (`{ pkgs, config, lib, ... }`), not `import` function patterns.
-4. **Consistent package pattern** — Each program gets one file in `modules/home/packages/`. Files use destructured module args.
+### New host
 
-## Adding a New Host
+1. Add entry to `hosts/default.nix` — fields: `system`, `username`, `useremail`, `hostname`, `githubuser`, `githubname`, `gpgkeyid`, `type`, `homeProfiles`.
+2. Create `profiles/darwin/<hostname>.nix` or `profiles/nixos/<name>.nix`.
+3. `just rebuild <hostname>`
 
-1. Add entry to `hosts/default.nix` with all required fields.
-2. Create profile in `profiles/darwin/<hostname>.nix` or `profiles/nixos/<name>.nix`.
-3. Run `just rebuild <hostname>`.
+### New package
 
-## Adding a New Package
+1. Create `modules/home/packages/<name>.nix`:
+   ```nix
+   { pkgs, ... }: {
+     programs.<name>.enable = true;  # prefer if module exists
+     # or: home.packages = [ pkgs.<name> ];
+   }
+   ```
+2. Add `../packages/<name>.nix` to the profile in `modules/home/profiles/<category>.nix`.
+3. `just rebuild <hostname>`
 
-1. Create `modules/home/packages/<name>.nix` with the program config.
-2. Add it to the appropriate profile in `modules/home/profiles/<category>.nix`.
+Profiles: `cli`, `shell`, `git`, `editors`, `security`, `macos`, `ai`.
+
+### Custom derivation (not in nixpkgs)
+
+1. Create `pkgs/custom/<name>.nix` using `pkgs.fetchurl` or `pkgs.fetchzip`.
+2. Reference as `pkgs.custom.<name>` — auto-discovered.
+
+### New darwin module
+
+1. Create `modules/darwin/<name>.nix` with `{ pkgs, config, lib, ... }: { ... }`.
+2. Add to `modules` list in `lib/default.nix` → `mkDarwinSystem`.
+3. If per-host config needed, add field to `hosts/default.nix` and pass via `specialArgs`.
+
+### New flake input
+
+1. Add to `inputs` in `flake.nix`.
+2. Access as `inputs.<name>`.
+3. If needed in `specialArgs`, add to `baseSpecialArgs` in `lib/default.nix`.
+
+## Adding agent skills
+
+Skills live in `skills/<name>/SKILL.md`. The `local` source is pre-configured.
+
+1. Create `skills/<name>/SKILL.md` with frontmatter:
+   ```markdown
+   ---
+   name: <name>
+   description: "<what it does and when>"
+   ---
+   ```
+2. Add `"<name>"` to `skills.enable` in `modules/home/packages/skills.nix`.
+3. `just rebuild`
+
+For external skills, see `skills/add-skill/SKILL.md`.
+
+## Key commands
+
+```bash
+just rebuild <host>   # Rebuild system
+just update           # Update flake inputs
+just fmt              # Format (treefmt)
+just check            # Flake checks
+just dev              # Dev shell
+just gc               # Garbage collect
+```
+
+## Verification
+
+Before rebuilding, eval to catch errors:
+
+```bash
+nix eval '.#darwinConfigurations.<host>.system' --impure
+nix eval '.#nixosConfigurations.<host>.system' --impure
+```
+
+## Design principles
+
+- **Data-driven hosts** — all per-host values in `hosts/default.nix`.
+- **One file per program** — `modules/home/packages/<name>.nix`.
+- **Profiles group packages** — `modules/home/profiles/<category>.nix` with `imports = [...]`.
+- **Standard module args** — `{ pkgs, config, lib, ... }`, not `import` function patterns.
 
 ## Converting from Homebrew
 
-When asked to convert a brew install to Nix:
+See `DOCS.md` for detailed examples. Summary:
 
-- **CLI tool (formula)** → `home.packages = [ pkgs.<name> ]` or `programs.<name>.enable = true` if a home-manager module exists.
-- **GUI app (cask)** → Same patterns, but check `https://search.nixos.org/packages` first — the Nix name often differs (e.g. `whatsapp-for-mac` not `whatsapp`).
-- **Not in nixpkgs** → Create a custom derivation in `pkgs/custom/<name>.nix` using `pkgs.fetchurl` or `pkgs.fetchzip`, then reference as `pkgs.custom.<name>`.
-- Always prefer `programs.<name>.enable` over `home.packages` when a home-manager module exists (gives config management).
-- Package modules go in `modules/home/packages/<name>.nix`, imported via `modules/home/profiles/<category>.nix`.
-
-## Key Commands
-
-- `just rebuild <host>` — Rebuild nix-darwin/NixOS
-- `just update` — Update flake inputs
-- `just fmt` — Format all files
-- `just check` — Run flake checks
-- `just dev` — Enter dev shell
-- `just gc` — Clean up generations and garbage collect
+- CLI formula → `programs.<name>.enable = true` or `home.packages = [ pkgs.<name> ]`
+- GUI cask → same, but search `https://search.nixos.org/packages` for the Nix name
+- Not in nixpkgs → `pkgs/custom/<name>.nix` with `fetchurl`/`fetchzip`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/DOCS.md
+++ b/DOCS.md
@@ -1,12 +1,10 @@
 # Operations Guide
 
-Common day-to-day tasks for this Nix config.
+Day-to-day tasks. For architecture and "how to add things", see `AGENTS.md`.
 
 ## Converting from Homebrew
 
-All packages are now managed through Nix. Here's how to convert common brew patterns:
-
-### Brew Formula (CLI Tool)
+### CLI tool (formula)
 
 ```nix
 # brew install bat        → modules/home/packages/bat.nix
@@ -23,9 +21,9 @@ All packages are now managed through Nix. Here's how to convert common brew patt
 }
 ```
 
-Check if a home-manager module exists (`programs.<name>.enable`) before falling back to `home.packages`.
+Prefer `programs.<name>.enable` when a home-manager module exists.
 
-### Brew Cask (GUI App)
+### GUI app (cask)
 
 ```nix
 # brew install --cask firefox    → modules/home/packages/firefox.nix
@@ -44,11 +42,11 @@ _: {
 }
 ```
 
-Search `https://search.nixos.org/packages` for the Nix package name — it often differs from the cask name.
+Search `https://search.nixos.org/packages` — the Nix name often differs from the cask name.
 
-### Not in nixpkgs?
+### Not in nixpkgs
 
-Create a custom derivation in `pkgs/custom/<name>.nix`:
+Create `pkgs/custom/<name>.nix`:
 
 ```nix
 { pkgs, lib, ... }:
@@ -65,105 +63,124 @@ pkgs.stdenv.mkDerivation {
 }
 ```
 
-Then reference as `pkgs.custom.<name>` in a package module.
+Reference as `pkgs.custom.<name>` in a package module.
 
-### Steps
+## Custom derivation patterns
 
-1. Create `modules/home/packages/<name>.nix` with the config
-2. Add `../packages/<name>.nix` to the appropriate profile in `modules/home/profiles/<category>.nix`
-3. Run `just rebuild <hostname>`
-
-Profiles: `cli`, `shell`, `git`, `editors`, `security`, `macos`, `ai`.
-
-## Add a Custom Package
-
-Two steps:
-
-1. Create the derivation in `pkgs/custom/<name>.nix` (e.g. fetch from GitHub or wrap a script)
-2. It's auto-discovered — reference as `pkgs.custom.<name>` anywhere
-
-If referencing a script in `scripts/`, use path `../../scripts/<file>.sh` (from `pkgs/custom/`).
-
-## Add a New Host
-
-1. Add entry to `hosts/default.nix` — required fields: `system`, `username`, `useremail`, `hostname`, `githubuser`, `githubname`, `gpgkeyid`, `type` (`"darwin"` / `"nixos"` / `"home-manager"`), `homeProfiles`.
-2. If `type = "darwin"`: create `profiles/darwin/<hostname>.nix` with `{ ... }: { }`
-3. If `type = "nixos"`: create `profiles/nixos/<name>.nix` and set `nixosProfile = "<name>"` in the host entry
-4. Run `just rebuild <hostname>`
-
-## Add a New Darwin Module
-
-Create `modules/darwin/<name>.nix`:
+### Rust package override
 
 ```nix
-{ pkgs, config, lib, ... }: {
-  # options and config here
-};
+(pkgs.FOO.overrideAttrs (finalAttrs: prevAttrs: {
+  cargoHash = "";  # build once, replace with hash
+  src = pkgs.fetchBAR { ... };
+  version = "...";
+  cargoDeps = pkgs.rustPlatform.fetchCargoTarball {
+    inherit (finalAttrs) pname src version;
+    hash = finalAttrs.cargoHash;
+  };
+}))
 ```
 
-Add to the module list in `lib/default.nix` → `mkDarwinSystem` → `modules` list.
+### Script from scripts/ directory
 
-If the module needs per-host config values, add the field to `hosts/default.nix` and pass it via `specialArgs`.
+In `pkgs/custom/<name>.nix`:
 
-## Add a Flake Input
-
-1. Add to `inputs` in `flake.nix`
-2. Access as `inputs.<name>` anywhere
-3. If needed as a `specialArg` in `lib/default.nix`, add it to `baseSpecialArgs` or the individual builder's `specialArgs`
-
-## Update Everything
-
-```sh
-just update       # nix flake update + optional determinate-nixd upgrade
+```nix
+{ pkgs, ... }:
+pkgs.writeShellApplication {
+  name = "my-script";
+  runtimeInputs = [ pkgs.coreutils ];
+  text = builtins.readFile ../../scripts/my-script.sh;
+}
 ```
 
-## Format & Check
+## Common errors
 
-```sh
-just fmt          # nix fmt (treefmt)
-just check        # nix flake check
+| Error                                                   | Fix                                                                                                                     |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `access to absolute path '/etc/nixos/...' is forbidden` | Add `--impure` — normal for NixOS                                                                                       |
+| `path '/nix/store/scripts/...' does not exist`          | Wrong relative path in `pkgs/custom/`. Use `../../scripts/<file>.sh`                                                    |
+| `Could not write domain ...com.apple.smb.server`        | Remove `system.defaults.smb.NetBIOSName` — plist doesn't exist until SMB sharing is enabled                             |
+| `file 'nixpkgs' was not found`                          | `sudo -i nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs && sudo -i nix-channel --update nixpkgs` |
+
+## SSL certificate fix
+
+```bash
+sudo rm /etc/ssl/certs/ca-certificates.crt
+sudo ln -s /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
 ```
 
-## Verify Before Rebuilding
+## Spotlight indexing for Nix apps
 
-Quick eval check without building:
+Nix-darwin links apps to `/Applications` directly. If you need Spotlight to find them, see the `home.activation.copyNixApps` pattern in `NOTES.md`.
 
-```sh
-nix eval '.#darwinConfigurations.<hostname>.system' --impure --no-write-lock-file
+## LaunchAgent management
+
+```bash
+# List services
+launchctl list | grep -i <name>
+
+# Kill a service
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/<name>.plist
+
+# Start a service
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<name>.plist
+
+# Remove dead plist
+rm ~/Library/LaunchAgents/<name>.plist
 ```
 
-For NixOS:
+## Atuin daemon fix
 
-```sh
-nix eval '.#nixosConfigurations.<hostname>.system' --impure --no-write-lock-file
+```bash
+pkill -9 atuin
+rm ~/.local/share/atuin/daemon.sock
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/org.nix-community.home.atuin-daemon
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/org.nix-community.home.atuin-daemon.plist
 ```
 
-For home-manager standalone:
+## Root fish shell
 
-```sh
-nix eval '.#homeConfigurations.<hostname>.home.activationPackage' --impure --no-write-lock-file
+```bash
+dscl . -read /Users/root UserShell
+sudo chsh -s /etc/profiles/per-user/kylewong/bin/fish root
 ```
 
-## Common Errors
+## GPG backup
 
-**`access to absolute path '/etc/nixos/configuration.nix' is forbidden in pure evaluation mode`**
-→ NixOS configs need `--impure` at build time. Normal.
+```bash
+gpg --list-secret-keys --keyid-format LONG
+# use the key after rsa4096 as input
+```
 
-**`path '/nix/store/scripts/...' does not exist`**
-→ Wrong relative path in `pkgs/custom/*.nix`. From `pkgs/custom/`, use `../../scripts/<file>.sh`.
+## Pass (secret manager)
 
-**`Could not write domain /Library/Preferences/SystemConfiguration/com.apple.smb.server`**
-→ Remove `system.defaults.smb.NetBIOSName` — plist doesn't exist on newer macOS until SMB sharing is enabled.
+Multi-machine setup:
 
-## Directory Reference
+1. Each machine has its own private key
+2. Exchange public keys between machines
+3. `pass init <pubkey-a> <pubkey-b>`
+4. Trust the other key: `pass --edit-key <pubkey> → trust → 5 → quit`
 
-| Path                          | Purpose                           |
-| ----------------------------- | --------------------------------- |
-| `hosts/default.nix`           | All per-host values               |
-| `modules/darwin/*.nix`        | Darwin system configs             |
-| `modules/home/packages/*.nix` | Program configs (one per file)    |
-| `modules/home/profiles/*.nix` | Category groups (import packages) |
-| `profiles/darwin/*.nix`       | Per-host darwin overrides         |
-| `pkgs/custom/*.nix`           | Custom derivations                |
-| `pkgs/overrides.nix`          | Package version overrides         |
-| `scripts/*.sh`                | Shell scripts                     |
+Key rotation: init with new keys first, verify access, then delete old keys.
+
+## OrbStack Docker in NixOS
+
+```bash
+mac link docker
+```
+
+See: https://github.com/orbstack/orbstack/issues/269#issuecomment-1548858675
+
+## Directory reference
+
+| Path                               | Purpose                           |
+| ---------------------------------- | --------------------------------- |
+| `hosts/default.nix`                | All per-host values               |
+| `modules/darwin/*.nix`             | macOS system configs              |
+| `modules/home/packages/*.nix`      | Program configs (one per file)    |
+| `modules/home/profiles/*.nix`      | Category groups (import packages) |
+| `modules/home/packages/skills.nix` | Agent skills configuration        |
+| `profiles/darwin/*.nix`            | Per-host darwin overrides         |
+| `pkgs/custom/*.nix`                | Custom derivations                |
+| `skills/*/SKILL.md`                | Local agent skills                |

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,43 @@
 {
   "nodes": {
+    "agent-skills": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "home-manager": "home-manager",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786379373,
+        "narHash": "sha256-zrvcpGFA8zG6yRLBqQH9bNkJap8xMvLNvkuT4+7w6X8=",
+        "owner": "Kyure-A",
+        "repo": "agent-skills-nix",
+        "rev": "1594ba479be81a7cb6dd19faabefcb1ed5b3f964",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Kyure-A",
+        "repo": "agent-skills-nix",
+        "type": "github"
+      }
+    },
+    "anthropics-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787332253,
+        "narHash": "sha256-nVid8vENmLDh7ffDqh+bJbEWtXcVltA0qa2rItmniZM=",
+        "owner": "anthropics",
+        "repo": "skills",
+        "rev": "3b3fad96af16a10759d930941b4520ba0c40edae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "anthropics",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "base16": {
       "inputs": {
         "fromYaml": "fromYaml"
@@ -68,6 +106,44 @@
         "type": "github"
       }
     },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "agent-skills",
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "cursor-plugins": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787281804,
+        "narHash": "sha256-rTkT/2dliMzvwDkza2+JNhSIzcTr9fXjvK2zwi/lRl8=",
+        "owner": "cursor",
+        "repo": "plugins",
+        "rev": "46125561306434d8a1d7745d540d8932ab0cd2a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cursor",
+        "repo": "plugins",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -96,12 +172,12 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1787168041,
-        "narHash": "sha256-KDdZe7z3BA1dYet02fDFTUplCl0gha+2ltGxMgCVA00=",
-        "rev": "6069a65ab09f683cfd9cb17b21a66a366c8077da",
-        "revCount": 432,
+        "lastModified": 1787341630,
+        "narHash": "sha256-LGGnqJH919hu3YKK0hC/3vsl3Glya4bbEoW7Lbok3gc=",
+        "rev": "b484316129e0089e28077f4ede85ac4dbd4b842f",
+        "revCount": 435,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.22.1/01a01b87-a478-7c30-bfa0-e436091ec74b/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/3.22.2/01a025df-f652-7701-a0cd-4f1373154572/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -111,37 +187,53 @@
     "determinate-nixd-aarch64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-wMxUMoLK3e68VTDdI8JC6fZKjBux7Meh8U+3g/wnKSE=",
+        "narHash": "sha256-76KjZDujSBvk+weVMPngpcbbERAdCozOXni6LII6M/g=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.1/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.2/macOS"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.1/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.2/macOS"
       }
     },
     "determinate-nixd-aarch64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-LqG2aJXwkAeemdmDvhWjADh2ZpadI32jrsFfCsZTa1Q=",
+        "narHash": "sha256-zr+VnNMCbERuf0mUOjJHBft/BwZdcjk4rKA7pXwRbSY=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.1/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.2/aarch64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.1/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.2/aarch64-linux"
       }
     },
     "determinate-nixd-x86_64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-sXxr7bL0luNTafC9rvjh34sE1nrub0UQjhB9KmHjum0=",
+        "narHash": "sha256-Rp0y7m4SQecV4R8wFjNLRIXcC73I4r4js+kAdAkoAbk=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.1/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.2/x86_64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.1/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/tag/v3.22.2/x86_64-linux"
+      }
+    },
+    "emil-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787304752,
+        "narHash": "sha256-VNTgOF9nKz+kkwVvuchepbi0q++2/PfT/gQpplpQcMc=",
+        "owner": "emilkowalski",
+        "repo": "skills",
+        "rev": "d23d7f88a2e21c9e4b1418c7abe420f5c1052ba7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "emilkowalski",
+        "repo": "skills",
+        "type": "github"
       }
     },
     "firefox-gnome-theme": {
@@ -253,7 +345,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -329,6 +421,27 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
+          "agent-skills",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
           "nixpkgs"
         ]
       },
@@ -343,6 +456,22 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/nix-community/home-manager/0.1"
+      }
+    },
+    "mattpocock-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787309793,
+        "narHash": "sha256-FPAAotNqA5aHrFDlj/XddoLs4TDKi+4J5H/mvevlOlk=",
+        "owner": "mattpocock",
+        "repo": "skills",
+        "rev": "5b15a47f2d7150f545fbcacbfe381787fc0230dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "type": "github"
       }
     },
     "mimi": {
@@ -367,12 +496,12 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1787286914,
-        "narHash": "sha256-GHWaDD1IbcJARHbu3gXWWg57NJ7+k4kQv3266PhTCaM=",
-        "rev": "66c4d204ea996ed674cd2cd103d70a703cf99862",
-        "revCount": 1295,
+        "lastModified": 1787312936,
+        "narHash": "sha256-JBOwPoPNJMwpPnlyf4E2l2sT1Pv+DYXyupdWlsR12/k=",
+        "rev": "4ee665ca28657b2bfab8af5e2b1a8362ef42d85e",
+        "revCount": 1296,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/y3owk1n/neru/0.1.1295%2Brev-66c4d204ea996ed674cd2cd103d70a703cf99862/01a0229a-e4f9-7d80-80ba-05acb2dbec93/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/y3owk1n/neru/0.1.1296%2Brev-4ee665ca28657b2bfab8af5e2b1a8362ef42d85e/01a02427-e5e6-7c40-a98f-7d5ba65d2c7c/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -388,12 +517,12 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1787146895,
-        "narHash": "sha256-zKZlnOTtMHwri2kxYPziIGkLL7Q9go0CrwGbZ/7wD6s=",
-        "rev": "9dee162cae223df4d358182b4871ebad258743aa",
-        "revCount": 27234,
+        "lastModified": 1787334067,
+        "narHash": "sha256-wmwgSBcAGJe/e+FrLwJxlghYV12F7UkIodm0j6cosYg=",
+        "rev": "c407745c8b9b616bebf7288697699c45794e31ac",
+        "revCount": 27248,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.22.1/01a01a62-3751-7452-879c-be17f74a7df2/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.22.2/01a02595-e77f-7e43-a616-5bbc77a2dc07/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -544,11 +673,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {
@@ -636,12 +765,12 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1786682862,
-        "narHash": "sha256-uRKXFtotQvKahpj17FSsgXZqXnULtYb+ft0vjazyOCI=",
-        "rev": "0100c5f6bf36889ac9f5cb9a61e10b978e547281",
-        "revCount": 558,
+        "lastModified": 1787312762,
+        "narHash": "sha256-lMOgMEmobHikKjfLQUO6D7w9Jvu4KSC+SoyIfL4tjFY=",
+        "rev": "d63ef3d8156be4d8d626b1d6954cc547db33070f",
+        "revCount": 566,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/y3owk1n/nvs/0.1.558%2Brev-0100c5f6bf36889ac9f5cb9a61e10b978e547281/019ffe99-806a-7151-acd2-3825b961be67/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/y3owk1n/nvs/0.1.566%2Brev-d63ef3d8156be4d8d626b1d6954cc547db33070f/01a02425-0abc-7731-8301-ad07fa39c0a3/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -668,19 +797,41 @@
     },
     "root": {
       "inputs": {
+        "agent-skills": "agent-skills",
+        "anthropics-skills": "anthropics-skills",
+        "cursor-plugins": "cursor-plugins",
         "darwin": "darwin",
         "determinate": "determinate",
+        "emil-skills": "emil-skills",
         "flake-parts": "flake-parts_2",
-        "home-manager": "home-manager",
+        "home-manager": "home-manager_2",
+        "mattpocock-skills": "mattpocock-skills",
         "mimi": "mimi",
         "neru": "neru",
         "nixgl": "nixgl",
         "nixpkgs": "nixpkgs_5",
         "nvs": "nvs",
         "pre-commit-hooks": "pre-commit-hooks",
+        "shadcn-ui": "shadcn-ui",
         "stylix": "stylix",
         "treefmt-nix": "treefmt-nix",
         "uts": "uts"
+      }
+    },
+    "shadcn-ui": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787333241,
+        "narHash": "sha256-2a51m6yXuJQVKvp4Oa2ep6FqNKk9nakmCxF8e7oK4i8=",
+        "owner": "shadcn-ui",
+        "repo": "ui",
+        "rev": "1773ecfeeb4a04366978d353e69b5c7ded78dcb2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shadcn-ui",
+        "repo": "ui",
+        "type": "github"
       }
     },
     "stylix": {
@@ -696,7 +847,7 @@
           "nixpkgs"
         ],
         "nur": "nur",
-        "systems": "systems_2",
+        "systems": "systems_3",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -731,6 +882,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1774449309,
         "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,32 @@
     nvs.url = "https://flakehub.com/f/y3owk1n/nvs/0.1";
     uts.url = "https://flakehub.com/f/y3owk1n/uts/0.1";
 
+    # Agent Skills
+    agent-skills = {
+      url = "github:Kyure-A/agent-skills-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    mattpocock-skills = {
+      url = "github:mattpocock/skills";
+      flake = false;
+    };
+    cursor-plugins = {
+      url = "github:cursor/plugins";
+      flake = false;
+    };
+    anthropics-skills = {
+      url = "github:anthropics/skills";
+      flake = false;
+    };
+    shadcn-ui = {
+      url = "github:shadcn-ui/ui";
+      flake = false;
+    };
+    emil-skills = {
+      url = "github:emilkowalski/skills";
+      flake = false;
+    };
+
     # Development Tools & Infrastructure
     flake-parts.url = "https://flakehub.com/f/hercules-ci/flake-parts/0.1";
     treefmt-nix.url = "https://flakehub.com/f/numtide/treefmt-nix/0.1";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,6 +67,7 @@ let
           inputs.neru.homeManagerModules.default
           inputs.nvs.homeManagerModules.default
           inputs.uts.homeManagerModules.default
+          inputs.agent-skills.homeManagerModules.default
         ]
         ++ (map profileModule homeProfiles);
       };
@@ -240,6 +241,7 @@ in
           inputs.neru.homeManagerModules.default
           inputs.nvs.homeManagerModules.default
           inputs.uts.homeManagerModules.default
+          inputs.agent-skills.homeManagerModules.default
         ]
         ++ (map (p: ../modules/home/profiles + "/${p}.nix") hostData.homeProfiles);
       }

--- a/modules/home/packages/skills.nix
+++ b/modules/home/packages/skills.nix
@@ -1,0 +1,137 @@
+{ lib, ... }:
+{
+  # Agent Skills declarative configuration
+  # Uses agent-skills-nix to manage skills across all harnesses
+
+  programs.agent-skills = {
+    enable = true;
+
+    # Declare skill sources
+    sources = {
+      # Local skills embedded in this repo
+      local = {
+        path = ../../../skills;
+      };
+
+      # Matt Pocock's skills (engineering, productivity, misc)
+      matt = {
+        input = "mattpocock-skills";
+        subdir = "skills";
+        idPrefix = "matt";
+        filter.maxDepth = 2;
+      };
+
+      # Cursor plugins (unslop, etc.)
+      cursor = {
+        input = "cursor-plugins";
+        subdir = "pstack/skills";
+        idPrefix = "cursor";
+      };
+
+      # Anthropic skills (frontend-design, etc.)
+      anthropic = {
+        input = "anthropics-skills";
+        subdir = "skills";
+        idPrefix = "anthropic";
+      };
+
+      # shadcn/ui skills
+      shadcn = {
+        input = "shadcn-ui";
+        subdir = "skills";
+        idPrefix = "shadcn";
+      };
+
+      # Emil Kowalski's skills (animation, design, etc.)
+      emil = {
+        input = "emil-skills";
+        subdir = "skills";
+        idPrefix = "emil";
+      };
+    };
+
+    # Enable specific skills from the catalog
+    skills.enable = [
+      # Local custom skills
+      "ship-spec"
+      "ship-ticket"
+      "add-skill"
+      "create-pr"
+      "find-skills"
+
+      # Cursor plugins
+      "cursor/unslop"
+
+      # Anthropic skills
+      "anthropic/frontend-design"
+
+      # shadcn/ui skills
+      "shadcn/shadcn"
+
+      # Emil Kowalski - Animation & Design
+      "emil/animate"
+      "emil/animation-vocabulary"
+      "emil/apple-design"
+      "emil/ask-sonner"
+      "emil/emil-design-eng"
+      "emil/find-animation-opportunities"
+      "emil/improve-animations"
+      "emil/pick-ui-library"
+      "emil/prototype"
+
+      # Matt Pocock - Engineering
+      "matt/engineering/ask-matt"
+      "matt/engineering/code-review"
+      "matt/engineering/codebase-design"
+      "matt/engineering/diagnosing-bugs"
+      "matt/engineering/domain-modeling"
+      "matt/engineering/grill-with-docs"
+      "matt/engineering/implement"
+      "matt/engineering/improve-codebase-architecture"
+      "matt/engineering/prototype"
+      "matt/engineering/research"
+      "matt/engineering/resolving-merge-conflicts"
+      "matt/engineering/setup-matt-pocock-skills"
+      "matt/engineering/tdd"
+      "matt/engineering/to-spec"
+      "matt/engineering/to-tickets"
+      "matt/engineering/triage"
+      "matt/engineering/wayfinder"
+      "matt/engineering/wizard"
+
+      # Matt Pocock - Productivity
+      "matt/productivity/grill-me"
+      "matt/productivity/grilling"
+      "matt/productivity/writing-for-agents"
+    ];
+
+    # Enable target harnesses for skill sync
+    targets = {
+      # Claude Code (~/.claude/skills)
+      claude.enable = true;
+
+      # Freebuff / generic agents (~/.agents/skills)
+      agents.enable = true;
+
+      # OpenCode (~/.config/opencode/skills)
+      opencode.enable = true;
+    };
+  };
+
+  # Flatten nested skills for Claude (it only scans one level deep)
+  home.activation.flattenClaudeSkills = lib.hm.dag.entryAfter [ "agent-skills" ] ''
+    claude_skills="$HOME/.claude/skills"
+    if [ -d "$claude_skills" ]; then
+      # Follow symlinks (-L) and find SKILL.md files nested more than 1 level deep
+      find -L "$claude_skills" -mindepth 3 -name 'SKILL.md' | while read -r skill_file; do
+        skill_dir="$(dirname "$skill_file")"
+        skill_name="$(basename "$skill_dir")"
+        target="$claude_skills/$skill_name"
+        # Only create if not already a direct child
+        if [ ! -e "$target" ] && [ ! -L "$target" ]; then
+          ln -s "$skill_dir" "$target"
+        fi
+      done
+    fi
+  '';
+}

--- a/modules/home/profiles/ai.nix
+++ b/modules/home/profiles/ai.nix
@@ -3,5 +3,6 @@
     ../packages/opencode.nix
     ../packages/freebuff.nix
     ../packages/claude.nix
+    ../packages/skills.nix
   ];
 }

--- a/skills/add-skill/SKILL.md
+++ b/skills/add-skill/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: add-skill
+description: "Adds a skill source or individual skill to the Nix configuration. Use when installing from skills.sh, a GitHub repo, or creating a local skill."
+---
+
+# Add Skill
+
+Two files control all skills:
+
+- `flake.nix` — declares sources as flake inputs
+- `modules/home/packages/skills.nix` — configures sources, enables skills
+
+Skills sync to `~/.claude/skills`, `~/.agents/skills`, `~/.config/opencode/skills` on `just rebuild`.
+
+## From a GitHub repo
+
+### 1. Find the skill path
+
+```bash
+cd /tmp && git clone --depth 1 <repo-url> && find <repo> -name 'SKILL.md'
+```
+
+Common patterns and their `subdir` values:
+| Path | `subdir` |
+|---|---|
+| `skills/<name>/SKILL.md` | `"skills"` |
+| `<plugin>/skills/<name>/SKILL.md` | `"<plugin>/skills"` |
+| `skills/<cat>/<name>/SKILL.md` | `"skills"` + `filter.maxDepth = 2` |
+
+### 2. Add flake input
+
+In `flake.nix`, under `# Agent Skills`:
+
+```nix
+<source-name> = {
+  url = "github:<owner>/<repo>";
+  flake = false;
+};
+```
+
+### 3. Add source
+
+In `modules/home/packages/skills.nix`, under `programs.agent-skills.sources`:
+
+```nix
+<source-name> = {
+  input = "<source-name>";       # must match flake input name
+  subdir = "<path-to-skills>";   # relative to repo root
+  idPrefix = "<prefix>";         # namespaces IDs (e.g. "matt", "cursor")
+};
+```
+
+### 4. Enable skills
+
+Add to `programs.agent-skills.skills.enable`:
+
+```nix
+"<idPrefix>/<skill-name>"        # e.g. "cursor/unslop"
+"<idPrefix>/<category>/<name>"   # e.g. "matt/engineering/tdd"
+```
+
+Skill ID format: `<idPrefix>/<relative-path-from-subdir>`.
+
+### 5. Verify
+
+```bash
+git add flake.nix modules/home/packages/skills.nix
+nix flake update <source-name>
+nix build '.#darwinConfigurations.Kyles-MacBook-Air.config.home-manager.users.kylewong.programs.agent-skills.bundlePath' --no-link --print-out-paths
+```
+
+Confirm the skill appears in the output.
+
+## Local skill
+
+1. Create `skills/<skill-name>/SKILL.md`:
+
+```markdown
+---
+name: <skill-name>
+description: "<what it does and when to use it>"
+---
+
+# <Skill Name>
+
+<instructions>
+```
+
+2. Add `"<skill-name>"` to `skills.enable` — the `local` source is pre-configured.
+
+## Skill sources
+
+Browse at [skills.sh](https://skills.sh/) or these repos:
+
+- `anthropics/skills` — document handling, design
+- `mattpocock/skills` — engineering, TDD, debugging
+- `cursor/plugins` — Cursor ecosystem
+- `vercel-labs/agent-skills` — React/Next.js
+- `emilkowalski/skills` — animation, design
+- `shadcn-ui/ui` — shadcn/ui components

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: create-pr
+description: "Commits changes and opens a pull request. Use when asked to commit, create a PR, open a pull request, or ship finished work."
+---
+
+# Create PR
+
+## Guardrails
+
+- **No AI attribution.** Never mention Claude, Anthropic, or AI in commits, PR title, body, or branch name.
+- **Never push to `main`.** New branch always.
+- **Explicit staging only.** No `git add -A` or `git add .` — stage paths individually.
+- **One change per commit, one change per PR.**
+
+## Steps
+
+1. **Branch.** `git switch -c <type>/<short-kebab-summary>` off `main`.
+2. **Verify.** Run CI checks (`just ci`, `make test`, `npm test`). Never open on red.
+3. **Stage selectively.** `git add <paths>` for this change only. Check `git status --short`.
+4. **Commit.** Format: `<type>(<scope>): <subject>` — imperative, lowercase, no period.
+5. **Check for template.** `ls .github/pull_request_template.md` and common locations. Use it if found.
+6. **Write PR body.** See template below. Open with `This PR <verb> ...`.
+7. **Grep for leaks.** Search commits and body for `claude`, `anthropic`, `co-authored`, `generated with`. Any hit is a bug.
+8. **Push and open.** `git push -u origin <branch>` then `gh pr create`.
+9. **Watch CI.** `gh pr checks --watch`. Fix failures yourself.
+
+## Commit format
+
+`<type>(<scope>): <subject>`
+
+Types: `feat`, `fix`, `perf`, `revert`, `docs`, `refactor`, `test`, `chore`, `ci`, `build`, `style`.
+
+Write the subject for a **user**, not the diff:
+
+- `fix(auth): handle expired tokens gracefully` ✓
+- `fix: update auth.go` ✗
+
+Body: explain _why_ and behaviour change, wrap at 72 chars. `Closes #123` when fixing an issue.
+
+## PR body (no template)
+
+```
+This PR <verb> ...
+
+## What changed
+
+<2-3 sentences: user-visible behaviour>
+
+## Why
+
+<1-2 sentences: motivation>
+
+## How to test
+
+<concrete steps>
+```
+
+Write for the **reader**, not the diff:
+
+- `This PR fixes button responsiveness on touch devices.` ✓
+- `Updates handleClick in Button.tsx` ✗
+
+Config/command changes: name them exactly as typed, note defaults, say whether existing configs keep working.

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query] [--owner <owner>]` - Search for skills interactively or by keyword, optionally scoped to a GitHub owner
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query] [--owner <owner>]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/skills/ship-spec/SKILL.md
+++ b/skills/ship-spec/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: ship-spec
+description: Work every ticket in a spec through to merge — implement, PR, review, merge, sync, repeat — one ticket at a time, each in a fresh context, harvesting the follow-up tickets each merge turns up.
+disable-model-invocation: true
+---
+
+# Ship a spec
+
+Picks up where `/to-tickets` left off and runs the **frontier** — the tickets whose blockers are all done — until it is empty. One ticket at a time, each carried from implementation to a merged PR before the next one starts.
+
+You are the **orchestrator**. You do not write the feature code: each ticket's implementation and each round of review fixes runs in a **fresh subagent**, so every ticket starts on a clean context and yours stays small enough to survive the whole spec. You hold the ledger; subagents hold the code.
+
+**Merging is the maintainer's call.** You open the PR and wait for the human to merge it — `gh pr merge` is never yours to run.
+
+## Guardrails
+
+- **The tracker is the state.** Recompute the frontier from it every round. Keeping a private ledger of what's done invites drift, and a run that survives a `/clear` needs its state on the tracker anyway.
+- **Each ticket gets its own branch off fresh `main`, in its own worktree** (see below). The main checkout stays on `main` for the whole run.
+- **Run the frontier in parallel, but only where tickets cannot clash.** Dispatch several ready tickets at once when each one's files and declarations are disjoint; keep a ticket back and run it sequentially whenever it could collide. See **Parallelism** below — the clash test is not optional, and when you cannot answer it confidently the answer is sequential.
+- **A round ends when its PRs are _open_, not when they merge.** Recompute the frontier and dispatch again the moment a ticket clears the clash test against everything still in flight. A run that waits for each merge before starting the next ticket puts CI and the maintainer's queue on the critical path of every ticket in turn — which is how a frontier of independent tickets comes to take as long as a chain of dependent ones.
+- **Never file a ticket without being asked to, one finding at a time.** A harvested finding is a _proposal_ until the user approves that specific ticket in that specific message. Ask with `AskUserQuestion`; a silent tracker write is the one failure this skill will not recover from. See **Harvesting**.
+- **Escalate contradictions.** When a ticket or a review comment fights the spec, or a decision the spec never made is forced, stop and ask the user with `AskUserQuestion`. Guessing is how a spec quietly becomes a different feature.
+- **`/implement`, `/to-spec` and `/to-tickets` are user-invoked** (`disable-model-invocation: true`) — no skill can call them, including you. Their behaviour is inlined into the briefs in `SUBAGENT-BRIEF.md` instead. `/tdd`, `/code-review` and a project `create-pr` skill are model-invocable, so subagents invoke those directly.
+
+## Process
+
+### 1. Resolve the run
+
+The argument is the spec: an issue number or URL, or a path to a `.scratch/<feature>/issues/` directory. With no argument, list the candidate specs you can find and ask which one.
+
+Read the project's tracker config (`docs/agents/issue-tracker.md`) and follow the matching section of [`TRACKERS.md`](TRACKERS.md) for every tracker operation below. Then read the **spec in full** — it is the contract each ticket is measured against, and the only thing that outlives a subagent's context.
+
+### 2. Preflight, once
+
+- `git status --porcelain` is empty, and `main` is checked out and pulled. A dirty tree stops the run — report what's uncommitted and let the user deal with it. Agent worktrees are the exception: they live in `.claude/worktrees/`, which many repos do not ignore, so they surface as untracked and are not dirt.
+- Find, from `AGENTS.md` / `CLAUDE.md`, four things, and put all four into every brief: the repo's **gate** command (`just ci`, `npm test`, …), its **fast checks** — lint, typecheck, build, whatever else runs in seconds and needs no database or container — its **regeneration** commands for checked-in generated artifacts, and its **stop** command for whatever the gate leaves running.
+- **The gate is CI's to run, not the subagent's.** Time it once during the preflight and compare it with what CI takes; where they are within a few minutes of each other, running it locally before the push buys a signal that is already on its way and puts the slowest step of the ticket on its critical path. Measured on kobai: the gate is 3m20s locally, CI is 4–5 minutes, and the fast checks plus the artifact-drift tests are about 30 seconds and catch every failure that is _certain_ rather than probable. So the briefs ask for the fast checks and the regeneration; the full run happens once, on the PR. Say so in the go-ahead below, because it changes what an open PR means: a PR is now _proposed_ green, not proven green, and it is the watcher that closes that gap.
+- Resolve any **untracked** material the briefs will cite — the spec itself, local agent overrides — to an absolute path in the main checkout, because a worktree will not contain it. `git check-ignore -v <path>` names the rule when you are unsure.
+- Show the user the ordered ticket list, the gate, and the PR flow, and get one go-ahead for the whole run. **That go-ahead covers shipping these tickets and nothing else** — not filing a follow-up, not widening a ticket's scope, not merging.
+
+### 3. The loop
+
+Repeat until the frontier is empty.
+
+**a. Pick the ticket.** Recompute the frontier from the tracker; take the first ticket whose blockers are all closed. Read its body now — not before.
+
+**b. Resume check.** If that ticket already has an open PR (a previous run, or a run that got cleared), skip to **e** with that PR.
+
+**c. Implement.** Run the clash test (see **Parallelism**) over the whole frontier, then dispatch a fresh `general-purpose` subagent with `isolation: "worktree"` and the implement brief from [`SUBAGENT-BRIEF.md`](SUBAGENT-BRIEF.md) for each ticket that clears it — in one message, so they run concurrently. Each returns a PR URL, a branch, and a short summary — or a question, which you escalate. Tickets that did not clear wait for the ones they would collide with to merge.
+
+**d. Link it.** Record the PR on the ticket so a resumed run finds it, and mark the ticket in progress.
+
+**d2. Go straight back to `a`.** Arm the watcher (**e**) and then recompute the frontier _immediately_ — do not wait for the merge. An open PR is out of your hands until an event arrives, and the twenty-odd minutes it spends in CI and in the maintainer's queue are minutes the next ticket could be using. Dispatch whatever now clears the clash test against every ticket still in flight; a ticket that clashes with one of them, or whose blocker is one of them, is the only kind that waits.
+
+The loop is over when the frontier is empty **and** nothing is still being watched — not when the last ticket is dispatched.
+
+**e. Watch the PR.** Arm the watcher through `Monitor` with `persistent: true` — `Monitor` **is** the harness's watching mechanism, and a PR can sit for hours, past any timeout:
+
+```bash
+~/.claude/skills/ship-spec/scripts/watch-pr.sh <pr-number>
+```
+
+It emits one line per state change and exits when the PR merges or closes. `Monitor` takes a command and has no PR-native mode, so that script is what fills the gap — emitting an event only when something moved is the difference between a handful of messages and one a minute. It is **shared with `/ship-ticket`**: both skills' `scripts/watch-pr.sh` are symlinks to `~/.claude/scripts/watch-pr.sh`, so fix it there and both skills get the fix. Never replace the symlink with a copy.
+
+Use `Monitor` rather than a background `Bash` here — the watch emits many events over the PR's life, and a backgrounded command is the right tool only when you want a single notification at the end. When an event is the user's to act on (green and quiet, or closed without merging), `PushNotification` is what reaches them; an event line only reaches you.
+
+**f. Handle each event.**
+
+- `checks-failed:`, `review-activity:`, `review-decision: CHANGES_REQUESTED` → dispatch a fresh subagent, also with `isolation: "worktree"`, using the review-round brief; then keep watching. A new subagent per round is what keeps review fixes off a context that has already spent itself on the implementation.
+- Green and quiet — no failing checks, no open threads → `PushNotification` the user **once** per PR: it is theirs to review.
+- `merged:` → `git pull` in the main checkout, **tear down that ticket's worktree and the containers it left running** (below), confirm the ticket closed, **write its findings down for the harvest** (below), and recompute the frontier — a merge is what releases the tickets that were held back for clashing with it. With several PRs in flight, this is per-PR: touch only the merged ticket's worktree and branch, and leave the others watching.
+- `closed-without-merge:` or `watch-error:` → stop and ask the user.
+
+### 4. Report
+
+Close with one line per ticket: number, title, PR, outcome. Name anything skipped or still open, and why. List the follow-ups you harvested, and the findings you declined to file.
+
+## Parallelism
+
+Several tickets in flight at once is the default when they are genuinely independent — it is most of the wall-clock saving this skill has to offer. It is also how two green PRs merge into a broken `main`, so the licence is narrow: **parallel only when the tickets cannot clash.**
+
+Before dispatching a round, run the clash test over every ticket on the frontier. Two tickets clash when any of these is true:
+
+- **Shared files.** They edit the same file — including the same generated artifact, the same guardrail test, the same doc page.
+- **Shared declaration.** One moves, renames or absorbs something the other reads or writes against, even in a different file. A ticket that relocates a table and a ticket written against that table's old home clash, and neither diff shows it.
+- **Ordered by design.** One is the other's blocker, or the tracker's dependency edge says so.
+- **Same narrow surface.** Both change the behaviour of one command, one port method, or one config key from different angles, so the merged result is a behaviour neither PR reviewed.
+
+Only the tickets that clear against _every_ already-dispatched ticket go out together; the rest wait. When you cannot answer the clash question confidently for a pair, they clash — the cost of being wrong is a broken `main` and a debugging session, and the cost of being cautious is one ticket's wall-clock.
+
+Tell each subagent what the others own. Name the files the concurrent tickets are touching and instruct it to stop and report rather than edit one, so a surprise overlap surfaces as a question instead of a merge conflict.
+
+Two practical consequences. Each agent runs the repo's full gate, so concurrent runs contend for the same machine and every gate gets slower — parallelism buys less than the ticket count suggests, and past a handful it buys nothing. And whichever PR merges second rebases onto the first: with a clean clash test that is a no-op, and when it is not, the clash test was wrong and is worth correcting before the next round.
+
+## Worktrees
+
+Every subagent runs in its own git worktree, so the main checkout stays on `main` for the whole run. Without it, each dispatch leaves the human's repo parked on whatever branch the last subagent was building, with its edits in the tree — and two agents cannot run at all.
+
+**The harness makes the worktree, not you.** `isolation: "worktree"` on the dispatch is the whole of it: the harness creates one under `.claude/worktrees/<name>` on a branch of its own and pins the subagent's working directory to it. Never `git worktree add` one yourself, and **never call `EnterWorktree`** — that moves _your_ session into a worktree, which is the opposite of what this run needs, and it is gated on the user asking for it besides.
+
+**A worktree holds only tracked files.** Everything git ignores is absent from it: a spec under an ignored path, `AGENTS.local.md` / `CLAUDE.local.md` overrides, any personal config the repo does not commit. `.git/info/exclude` is shared from the common directory, so the ignore _rule_ applies while the _file_ is missing — which is why this fails silently rather than loudly.
+
+So anything the briefs cite that is not tracked goes in as an **absolute path into the main checkout**, marked read-only. Resolve those paths once during the preflight and reuse them in every brief. A repo-relative path resolves inside the worktree, where the file does not exist, and the subagent either reports it missing or works without it and never says so.
+
+**Rebase on `origin/main` throughout, not just at branch time.** One ticket is in flight at a time, but `main` still moves underneath it — other sessions merge, the human pushes, a dependency lands. A branch cut hours ago and never refreshed is how two individually-correct PRs combine into a broken `main`: one renames a helper, the other was written against the old signature and merged without seeing it, and CI on each was green.
+
+So the briefs tell the subagent to `git fetch origin` and rebase onto `origin/main` **before running the gate and again before opening the PR**, and review rounds do the same before pushing. A gate run against a stale base proves less than it appears to. After a rebase on a pushed branch, force-push with `--force-with-lease`.
+
+**A worktree branches from `origin/main`, not from your checkout.** That is the `worktree.baseRef` setting and `fresh` is its default, so a stale local `main` does not reach the subagent and pulling first does not "give it a current base" — it already had one. Pull anyway, for the two things it _is_ load-bearing for: your own reading of the merged result, and checking `main` is green before you spend a ticket on it, since the subagent will report your repo's failure as if it were its own. Where a repo has set `baseRef: head`, the pull becomes the base too — check which you are on before trusting either sentence.
+
+**Teardown is yours, and it needs the path.** The harness removes a worktree it made only when the agent left it _unchanged_, which a shipped ticket never does — so the directory survives the run and `.claude/worktrees/` accumulates one per ticket until somebody clears it. `ExitWorktree` will not do this: it only touches a worktree `EnterWorktree` made in this session, and this one was made by a dispatch. So the briefs return the worktree path, and you remove it with `git worktree remove` from the main checkout.
+
+**Tear down at the merge, not before.** The branch and its worktree are how a resumed run picks a ticket back up mid-PR. Once the PR merges: remove the worktree, prune, delete the merged branch, and pull `main`. Run the removal from the main checkout — `git worktree remove` fails if the working directory is inside the worktree being removed. Remove only worktrees this run created, by exact path, and never with `--force` — another session's worktree may sit in the same directory.
+
+**A worktree is not the only thing a ticket leaves behind, and the other one outlives it.** Where the repo derives a container stack per checkout — a compose project named from the worktree's path, which is what lets two checkouts run their gates at once — the subagent's gate started that stack and nothing stops it. Removing the worktree then orphans it: the databases stay up, holding RAM and CPU on the machine every later gate has to share, and once the path is gone there is nothing left to name them by. Observed on kobai: fifteen Postgres containers running, the oldest eighteen hours old, six of them belonging to worktrees that had already been torn down.
+
+So **bring the stack down before you remove the directory**, in that order, from inside the worktree while its own environment still resolves — `devbox run down` and `devbox run db:down`, or `docker compose down -v`, whatever the repo's stop command is. If the directory is already gone, the containers are findable by their compose-project label and not otherwise:
+
+```bash
+docker ps -aq --filter "label=com.docker.compose.project=<project>" | xargs -r docker rm -f
+docker volume ls -q --filter "label=com.docker.compose.project=<project>" | xargs -r docker volume rm
+```
+
+Add the stop command to the preflight alongside the gate command, so every ticket's teardown has it.
+
+## Harvesting
+
+Every implement brief tells the subagent to report adjacent problems rather than fix them, so each merge leaves a small pile of findings. **Write each one down as it arrives — one line, in your ledger beside the ticket — and harvest the pile once, at the end of the run.**
+
+Harvesting at each merge is what this used to say, and it costs more than it looks. Every finding is an `AskUserQuestion`, every question is a human round trip, and the frontier stands still for the length of it — so a spec's wall-clock came to include the maintainer's response time once per finding, on a loop whose whole design is that tickets do not wait for each other. Held to the end, the questions are answered while nothing is pending, and the answers are better besides: by then the run knows whether a later ticket absorbed the finding, and whether the scope the subagent claimed for it held up across the rest of the spec.
+
+The one thing that trades away is durability — a finding lives in your context until it is asked about. So **if your context is going before the frontier empties, harvest what you are holding then** rather than losing it. That is the only reason to interrupt the loop for this.
+
+**Verify a finding before you file it.** A subagent reports what it saw from inside one ticket, and the scope it names is often wrong — one run reported a two-platform problem that a later ticket found on three. Check it against the code yourself. The ticket is only as good as the facts in it, and a wrong count sends the next agent down the wrong path.
+
+**Search the tracker before proposing anything.** A finding surfaced from inside one ticket looks novel from in there and often is not — the repo may already have an issue for it, possibly with a PR in flight. Search by the symptom and by the file, not by the wording you would use for the title.
+
+**The user decides what gets filed, every time, one finding at a time.** Present the survivors as a short list — one line each: what it is, why it qualifies, the title you would give it — then **stop and ask with `AskUserQuestion`**, and wait for an answer. Nothing is written to the tracker before that answer arrives.
+
+Four things this rules out, because each is a way a run files a ticket nobody asked for:
+
+- **No batch yes.** Approval covers the one finding it names. Three findings is three answers, even when the user said "yes" quickly to the first two.
+- **No standing approval.** The go-ahead for the run does not extend to filing, a previous round's approval does not carry to this one, and neither does approval given for a finding that turned out to be a different finding on inspection.
+- **No inferred yes.** Silence, "sounds good", "makes sense", or a reply about something else is not approval. Only an answer to the question you asked, about the ticket you described, is.
+- **No filing on the way past.** Not while closing out a merge, not while writing the final report, not "so it isn't lost". A finding the user declined or never ruled on goes in the report as prose and nowhere else.
+
+Approval to file is also not approval to do the work: file the ticket, say so, and leave it on the tracker. Filing is cheap to do and tedious to undo, and a tracker filling up with an agent's by-products is the failure mode this guards against.
+
+Propose a finding when it is real, outlives this spec, and no open ticket covers it. Leave it where it is when:
+
+- **A decision already ruled on it.** A finding that reopens what the spec, an ADR, or an earlier grill settled is not new information.
+- **It is the first step of work nobody has designed yet.** That is scope creep wearing a ticket's clothes — name it in your report and let the human decide whether it earns its own design pass.
+- **The ticket in flight already absorbed it.**
+
+Filed tickets go on the tracker, never in your head: the frontier is recomputed from there, so a follow-up joins the queue by construction. Give it a blocking edge only where one genuinely exists — most follow-ups are independent and run last.
+
+Report both halves, with a reason each. The declines are the more useful half — they are the record of what the run decided _not_ to do, and without them the same finding comes back next spec as a fresh idea.
+
+## Escalating
+
+Stop the loop and ask when:
+
+- A review comment contradicts the ticket or the spec.
+- Two tickets disagree about the same interface — the spec needs a ruling, not a coin flip.
+- The gate stays red after the subagent's own attempts to fix it.
+- A ticket's blockers never clear (a blocker was closed without merging, or the edges are cyclic).
+- The PR is closed without merging.
+
+## When your own context fills
+
+Everything needed to resume lives on the tracker: which tickets are closed, which are in progress, and their PRs. Tell the user to `/clear` and re-invoke `/ship-spec` with the same spec reference — the resume check in **3b** picks the run up mid-PR.
+
+To delay that as long as possible, keep only ticket numbers, statuses, PR numbers and one-line outcomes in your context — with several tickets in flight this matters more, not less, since each returns its own report. Read ticket bodies at dispatch time, and let the subagents' return values stay summaries — never ask one for a diff.

--- a/skills/ship-spec/SUBAGENT-BRIEF.md
+++ b/skills/ship-spec/SUBAGENT-BRIEF.md
@@ -1,0 +1,64 @@
+# Subagent briefs
+
+Two briefs, both dispatched to a `general-purpose` subagent. Each one is written for a **fresh context**: the subagent has never seen the spec, the ticket, or the conversation you had about them, so anything it needs to do the work has to be in the brief or reachable from a reference it can fetch itself.
+
+Fill every `<…>` before dispatching. Pass references (issue numbers, paths) rather than pasted bodies — the subagent fetching them itself keeps your context clear and its copy current.
+
+## Implement brief
+
+```markdown
+You are implementing one ticket in <repo path>. You are in your own git worktree on a clean checkout of `main` — work here, and leave the main checkout alone.
+
+Ticket: <ticket ref — issue number or file path>
+Spec: <spec ref — an absolute path if it is untracked, since your worktree holds only tracked files; read it, do not try to commit it>
+
+1. Read the ticket and the spec in full. Read `AGENTS.md` / `CLAUDE.md` at the repo root and the nearest nested one to the code you're touching — they carry contracts you cannot infer from the code.
+2. You are already on a fresh branch cut from `origin/main` — do not assume you are on `main`, and do not branch again from a local ref. Rename it to the repo's convention if it has one: `git branch -m <type>/<short-kebab-summary>`.
+3. Build the ticket's end-to-end behaviour, and only that. Adjacent problems you spot get reported back, not fixed here.
+   - Use the `matt/engineering/tdd` skill at the seams the spec names.
+   - Run typechecking and **the affected test files by name** as you go — never the full gate. The whole suite is what step 5 is for, and running it as an inner loop is the single easiest way to spend half an hour proving the same thing repeatedly.
+4. Review your own work with the `matt/engineering/code-review` skill, against the ticket as the spec axis. Fix what it finds.
+5. **Regenerate whatever your change invalidated**: `<the repo's regeneration commands>`. A checked-in generated artifact that nobody regenerated is the one failure that is certain rather than probable, and it is the one CI cannot tell you anything you did not already know.
+6. `git fetch origin && git rebase origin/main`, then run the **fast checks only** — `<fast check commands>` — plus, by name, the test files your change touches. **Do not run the full gate.** Then commit and open the PR with <the `create-pr` skill | `gh pr create`>. The PR body states what changed for a user and links the ticket (`Closes #<n>`).
+
+**CI is the gate, and running it twice does not make it truer.** The full suite takes minutes, CI runs the identical command on the identical commit within a few minutes of the push, and the orchestrator is already watching for `checks-failed:` — so a local run buys a signal you are about to be handed for free, at the price of the slowest step in the whole ticket. What the fast checks and the regeneration above cover is the part CI would tell you about _late_: a type error, a lint finding, a stale generated file. What they do not cover is behaviour, and behaviour is what CI is for.
+
+Push on green fast checks even if the full suite would have had more to say. **Do not push on a red one** — a type error or a lint finding is yours, it is seconds away from being fixed, and a PR opened with one is a round trip for something you could see.
+
+If a check fails on something you did not touch — locally or in CI — see whether it also fails on a clean `origin/main` before debugging it. A broken base is the repo's problem to fix, not yours to absorb into this ticket; report it instead.
+
+Stop and return a question instead of guessing when the ticket contradicts the spec, when the codebase has moved far enough that the ticket's approach no longer fits, or when a decision neither document made would change the interface.
+
+Return, and nothing more:
+
+- PR url, branch name, and the absolute path of this worktree (`git rev-parse --show-toplevel`) — the orchestrator removes it once the PR merges
+- 3-5 sentences on what you built and any deliberate limitation
+- anything the maintainer should look at closely
+- **adjacent findings** — each problem you spotted and left alone, with the scope you believe it has and what fixing it would take. Name the files you checked, so the orchestrator can verify the scope before filing a ticket on it.
+
+  **Do not file any of them.** Create no issues, open no tickets, edit nothing on the tracker beyond the PR link this ticket needs — filing is the maintainer's call and they have not been asked yet. A finding you file instead of report is one that skipped that question.
+
+- questions, if you stopped for one
+```
+
+## Review-round brief
+
+```markdown
+You are addressing review feedback on PR #<n> in <repo path> (ticket <ticket ref>, spec <spec ref> — an absolute path if it is untracked, since your worktree holds only tracked files). You are in your own git worktree; work here and leave the main checkout alone.
+
+1. Fetch and check out the PR branch in your worktree.
+2. Gather every open thread: `gh pr view <n> --comments`, the inline threads
+   (`gh api repos/<owner>/<repo>/pulls/<n>/comments`), and any failing checks
+   (`gh pr checks <n>`).
+3. Address each one. Group related fixes into one commit each, with the repo's commit conventions.
+4. Reply to each thread with what changed, in one line. Leave the threads for the maintainer to resolve — that's the reviewer's call.
+5. `git fetch origin && git rebase origin/main`, re-run the **fast checks** (`<fast check commands>`) and the test files the round touched, then push (`--force-with-lease` after a rebase). Not the full gate — CI runs it on the push, and the orchestrator is watching.
+
+Fix everything you can. Escalate — leave the code untouched for that thread and report it — when a comment contradicts the ticket or the spec, forces a design decision neither document made, or asks for work outside this ticket's scope.
+
+Return, and nothing more:
+
+- one line per thread: what you changed, or why you escalated
+- the gate result after your push
+- whether the PR is now ready for another look
+```

--- a/skills/ship-spec/TRACKERS.md
+++ b/skills/ship-spec/TRACKERS.md
@@ -1,0 +1,45 @@
+# Tracker operations
+
+Four operations drive the loop, whatever the tracker: **list the tickets**, **compute the frontier**, **record a PR on a ticket**, **confirm a ticket is done**. `docs/agents/issue-tracker.md` says which tracker this repo uses; follow that section. Anything it states beyond these operations — repo-specific labels, a project `create-pr` skill, PR conventions — wins over what's here.
+
+## GitHub (`gh`)
+
+The spec is an issue. Each ticket is its own issue carrying a `## Parent` section that references the spec — `/to-tickets` writes that link as text, so a spec's tickets are found by search, not by the native `parent` field (which stays empty unless the repo uses sub-issues).
+
+- **List** — `gh issue list --state all --limit 50 --search "<spec-number> in:body" --json number,title,state`, then keep the issues whose body really has `## Parent` → the spec, dropping the spec issue itself. Where a repo does use sub-issues, `gh issue view <spec> --json subIssues` is the exact answer.
+
+  Ascending issue number **is** dependency order — `/to-tickets` publishes blockers first.
+
+- **Frontier** — `gh issue view <n> --json blockedBy` returns each blocker with its state, so a ticket is ready when no blocker is `OPEN`:
+
+  ```bash
+  gh issue view <n> --json number,blockedBy \
+    --jq 'if [.blockedBy.nodes[]? | select(.state == "OPEN")] == [] then "ready" else "blocked" end'
+  ```
+
+  Prefer this over the REST `issue_dependencies_summary` — one call, and it names the blockers rather than counting them. Where a repo has no dependency links, parse the `Blocked by: #n` line in the body and check each referenced issue is closed.
+
+- **Resume check** — `gh issue view <n> --json closedByPullRequestsReferences` lists linked PRs on **open** issues too, so an open ticket with a PR there is a run to pick up rather than restart. Confirm with `gh pr view <pr> --json state,isDraft`.
+
+- **Record a PR** — the `Closes #<n>` line in the PR body creates that link. Add `gh issue edit <n> --add-assignee @me` so the ticket also reads as in flight to a human.
+
+- **Done** — the issue is closed, which `Closes #<n>` does on merge. If it is still open after the merge, close it yourself.
+
+## Local markdown
+
+Tickets are files under `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered in dependency order.
+
+- **List** — the files, in numeric order.
+- **Frontier** — read each file's `**Blocked by:**` line; a ticket is ready when every ticket it names has `**Status:** done`.
+- **Record a PR** — set `**Status:** in-progress` and append a `**PR:** <url>` line.
+- **Done** — set `**Status:** done`. Commit the status change with the merge, so the ledger and the code move together.
+
+The resume check is the `**PR:**` line on an `in-progress` ticket.
+
+## GitLab (`glab`)
+
+As GitHub, with `glab issue` / `glab mr` in place of `gh issue` / `gh pr`, and merge requests in place of pull requests. Blocking edges are GitLab's **blocked by** links (`glab api` on the issue links endpoint) or the same `Blocked by:` body line as a fallback.
+
+## Anything else
+
+`docs/agents/issue-tracker.md` records the workflow as prose. Map the four operations onto it before starting, and confirm the mapping with the user in the preflight — a wrong frontier query silently works the wrong ticket first.

--- a/skills/ship-ticket/SKILL.md
+++ b/skills/ship-ticket/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: ship-ticket
+description: Work one ticket through to merge in this session — implement it, open the PR, run the review rounds, and harvest the follow-ups the merge turns up. The single-ticket sibling of /ship-spec; reach for it when there is one issue to land rather than a whole spec.
+disable-model-invocation: true
+---
+
+# Ship a ticket
+
+Takes **one** ticket from where it sits on the tracker to a merged PR. Nothing else — no frontier, no queue, no next ticket. When the PR merges, the run is over.
+
+This is `/ship-spec` with the loop taken out, and with it the orchestration. **You do the work yourself, in this session, on a branch in the main checkout.** One ticket does not need a subagent: dispatching one would buy a clean context and cost you every detail of the implementation at exactly the moment review feedback arrives asking about it. `/ship-spec` pays that price because it ships many tickets and cannot hold them all; you are shipping one.
+
+**Merging is the maintainer's call.** You open the PR and wait for the human to merge it — `gh pr merge` is never yours to run.
+
+## Guardrails
+
+- **The tracker is the state.** The ticket's status and its linked PR are what a resumed run reads. Keeping a private ledger invites drift, and a run that survives a `/clear` needs its state on the tracker anyway.
+- **One ticket.** If the ticket turns out to need another one landed first, stop and say so — do not quietly ship the blocker too. Shipping the queue is `/ship-spec`'s job.
+- **Never file a ticket without being asked to, one finding at a time.** A harvested finding is a _proposal_ until the user approves that specific ticket in that specific message. Ask with `AskUserQuestion`; a silent tracker write is the one failure this skill will not recover from. See **Harvesting**.
+- **Escalate contradictions.** When the ticket or a review comment fights the spec it came from, or forces a decision nobody has made, stop and ask the user with `AskUserQuestion`. Guessing is how a ticket quietly becomes a different feature.
+- **`/implement`, `/to-spec` and `/to-tickets` are user-invoked** (`disable-model-invocation: true`) — no skill can call them, including you. What `/implement` would have done is written out in step 4 instead. `/tdd` and `/code-review` are model-invocable, and so is a project `create-pr` skill, so invoke those directly.
+
+## Process
+
+### 1. Resolve the ticket
+
+The argument is the ticket: an issue number or URL, or a path to a ticket file. With no argument, list the open tickets you can find and ask which one.
+
+Read the project's tracker config (`docs/agents/issue-tracker.md`) and follow the matching section of [`TRACKERS.md`](TRACKERS.md) for every tracker operation below. Then read the **ticket in full**.
+
+**Find its spec, if it has one.** A ticket written by `/to-tickets` carries a `## Parent` section pointing at the spec issue; a ticket filed by hand may reference an ADR or a design doc instead, or nothing. Read whatever it names — that is the contract the work is measured against. A ticket with no parent is measured against itself, which is fine, and worth saying out loud in the preflight so the user can correct you.
+
+**Check the blockers.** If the ticket names blockers that are still open, stop and report them. One ticket whose foundations are missing is not a run to start.
+
+### 2. Preflight
+
+- `git status --porcelain` is empty, and `main` is checked out and pulled. A dirty tree stops the run — report what's uncommitted and let the user deal with it.
+- `main` is actually green. Starting a ticket on a broken base wastes the work and disguises the repo's failure as yours.
+- Find the repo's gate command from `AGENTS.md` / `CLAUDE.md` (`just ci`, `npm test`, …), and whether a project `create-pr` skill exists.
+- Show the user the ticket, the spec it is measured against (or that there is none), the gate, and the PR flow, and get one go-ahead. **That go-ahead covers shipping this ticket and nothing else** — not filing a follow-up, not widening the ticket's scope, not merging.
+
+### 3. Resume check
+
+If the ticket already has an open PR — a previous run, or one that got cleared — check out that branch and skip to **6**. A half-shipped ticket is picked up, never restarted.
+
+### 4. Implement
+
+Work on a branch in the main checkout: `git fetch origin && git switch -c <type>/<short-kebab-summary> origin/main`. Branching from `origin/main` rather than from local `main` is what makes the pull in the preflight a convenience rather than a correctness step.
+
+1. Read `AGENTS.md` / `CLAUDE.md` at the repo root and the nearest nested one to the code you're touching — they carry contracts you cannot infer from the code.
+2. Build the ticket's end-to-end behaviour, and only that. **Adjacent problems get written down, not fixed** — that list is what **Harvesting** collects at the merge, and a fix that rides along is a fix nobody reviewed against a ticket.
+   - Use the `matt/engineering/tdd` skill at the seams the ticket names.
+   - Run typechecking and **the affected test files by name** as you go — never the full gate. The whole suite is what step 4 is for, and running it as an inner loop is the easiest way there is to spend half an hour proving the same thing repeatedly.
+3. Review your own work with the `matt/engineering/code-review` skill, against the ticket as the spec axis. Fix what it finds.
+4. **Regenerate whatever the change invalidated** — every checked-in generated artifact the repo compares byte for byte. That is the one failure that is certain rather than probable, and the one CI cannot tell you anything you did not already know.
+5. `git fetch origin && git rebase origin/main`, then run the **fast checks** — lint, typecheck, build, whatever else runs in seconds without a database or a container — plus, by name, the test files this ticket touched. **Do not run the full gate.** If something fails on code you did not touch, check whether it also fails on a clean `origin/main` before debugging it — a broken base is the repo's problem, not this ticket's to absorb.
+
+**CI is the gate, and running it twice does not make it truer.** The full suite takes minutes, CI runs the identical command on the identical commit a few minutes after the push, and step 6 is already watching for `checks-failed:` — so a local run buys a signal that is on its way, at the price of the slowest step in the ticket. The fast checks cover what CI would otherwise tell you _late_: a type error, a lint finding, a stale generated file. Behaviour is what CI is for. **Push on green fast checks; never on a red one** — a type error is yours, it is seconds from being fixed, and a PR opened with one is a round trip for something you could see.
+
+### 5. Open the PR
+
+Commit and open the PR — with the project's `create-pr` skill if it has one, otherwise `gh pr create`. The body states what changed for a user and links the ticket (`Closes #<n>`).
+
+**Do not re-run the gate here.** If `origin/main` moved between step 4 and this one, push anyway and let CI answer: it is the same gate on the same commit, it is already going to run, and a second local pass buys a signal you are about to be handed for free. The rebase in step 4 is what makes the base current; a second one is only worth taking if the merge itself conflicts.
+
+Then **link it**: record the PR on the ticket so a resumed run finds it, and mark the ticket in progress.
+
+### 6. Watch the PR
+
+Arm the watcher through `Monitor` with `persistent: true` — `Monitor` **is** the harness's watching mechanism, and a PR can sit for hours, past any timeout:
+
+```bash
+~/.claude/skills/ship-ticket/scripts/watch-pr.sh <pr-number>
+```
+
+It emits one line per state change and exits when the PR merges or closes. `Monitor` takes a command and has no PR-native mode, so that script is what fills the gap — emitting an event only when something moved is the difference between a handful of messages and one a minute. It is **shared with `/ship-spec`**: both skills' `scripts/watch-pr.sh` are symlinks to `~/.claude/scripts/watch-pr.sh`, so fix it there and both skills get the fix. Never replace the symlink with a copy.
+
+Use `Monitor` rather than a background `Bash` here — the watch emits many events over the PR's life, and a backgrounded command is the right tool only when you want a single notification at the end. When an event is the user's to act on (green and quiet, or closed without merging), `PushNotification` is what reaches them; an event line only reaches you.
+
+Handle each event:
+
+- `checks-failed:`, `review-activity:`, `review-decision: CHANGES_REQUESTED` → run a review round (**7**), then keep watching.
+- Green and quiet — no failing checks, no open threads → `PushNotification` the user **once**: the PR is theirs to review.
+- `merged:` → `git switch main && git pull`, delete the merged branch, confirm the ticket closed, **harvest the findings** (below), and report (**8**).
+- `closed-without-merge:` or `watch-error:` → stop and ask the user.
+
+### 7. Review rounds
+
+Stay on the branch and fix them here.
+
+1. Gather every open thread: `gh pr view <n> --comments`, the inline threads (`gh api repos/<owner>/<repo>/pulls/<n>/comments`), and any failing checks (`gh pr checks <n>`).
+2. Address each one, grouping related fixes into a commit each, with the repo's commit conventions.
+3. Reply to each thread with what changed, in one line. **Leave the threads for the maintainer to resolve** — that is the reviewer's call, not yours.
+4. `git fetch origin && git rebase origin/main`, re-run the gate, then push (`--force-with-lease` after a rebase).
+
+Fix everything you can. **Escalate** — leave that thread's code untouched and ask — when a comment contradicts the ticket or its spec, forces a design decision neither document made, or asks for work outside this ticket's scope.
+
+**Rebase every round, not just at branch time.** A ticket takes as long as its review rounds take, and `main` moves underneath it the whole while — other sessions merge, the human pushes, a dependency lands. A branch cut hours ago and never refreshed is how two individually-correct PRs combine into a broken `main`: one renames a helper, the other was written against the old signature and merged without seeing it, and CI on each was green. A gate run against a stale base proves less than it appears to.
+
+### 8. Report
+
+Close with the ticket number and title, the PR, and the outcome. Name what the implementation deliberately left out, anything the maintainer should look at closely, and how many review rounds it took. List the follow-ups you harvested, and the findings you declined to file.
+
+## Harvesting
+
+Step 4 says adjacent problems get written down rather than fixed, so the merge leaves a small pile of findings. Harvest them **at the merge**, while the work is still fresh — a finding not acted on then dies with your context.
+
+**Verify a finding before you propose it.** What looked like a two-file problem from inside the ticket is often wider or narrower. Check it against the code now that you are out of the change. The ticket is only as good as the facts in it, and a wrong scope sends the next person down the wrong path.
+
+**Search the tracker before proposing anything.** A finding surfaced from inside one ticket looks novel from in there and often is not — the repo may already have an issue for it, possibly with a PR in flight. Search by the symptom and by the file, not by the wording you would use for the title.
+
+**The user decides what gets filed, every time, one finding at a time.** Present the survivors as a short list — one line each: what it is, why it qualifies, the title you would give it — then **stop and ask with `AskUserQuestion`**, and wait for an answer. Nothing is written to the tracker before that answer arrives.
+
+Four things this rules out, because each is a way a run files a ticket nobody asked for:
+
+- **No batch yes.** Approval covers the one finding it names. Three findings is three answers, even when the user said "yes" quickly to the first two.
+- **No standing approval.** The go-ahead for the run does not extend to filing, a previous round's approval does not carry to this one, and neither does approval given for a finding that turned out to be a different finding on inspection.
+- **No inferred yes.** Silence, "sounds good", "makes sense", or a reply about something else is not approval. Only an answer to the question you asked, about the ticket you described, is.
+- **No filing on the way past.** Not while closing out a merge, not while writing the final report, not "so it isn't lost". A finding the user declined or never ruled on goes in the report as prose and nowhere else.
+
+Approval to file is also not approval to do the work: file the ticket, say so, and leave it on the tracker. Filing is cheap to do and tedious to undo, and a tracker filling up with an agent's by-products is the failure mode this guards against.
+
+Propose a finding when it is real, outlives this ticket, and no open ticket covers it. Leave it where it is when:
+
+- **A decision already ruled on it.** A finding that reopens what the spec, an ADR, or an earlier grill settled is not new information.
+- **It is the first step of work nobody has designed yet.** That is scope creep wearing a ticket's clothes — name it in your report and let the human decide whether it earns its own design pass.
+- **The ticket already absorbed it.**
+
+Report both halves, with a reason each. The declines are the more useful half — they are the record of what the run decided _not_ to do, and without them the same finding comes back next time as a fresh idea.
+
+## Escalating
+
+Stop and ask when:
+
+- A review comment contradicts the ticket or the spec it came from.
+- The ticket turns out to depend on work that has not landed.
+- The gate stays red after your own attempts to fix it.
+- The PR is closed without merging.
+
+## When your own context fills
+
+Doing the work here rather than in a subagent spends your context on the implementation, so this is the run's real limit — and the reason it is safe is that **nothing lives only in your head**. The branch is pushed, the PR is open, the ticket links it, and the findings you have not harvested yet are the ones you wrote down.
+
+When the context is going: push what you have, make sure the PR exists and the ticket links it, then tell the user to `/clear` and re-invoke `/ship-ticket` with the same ticket reference. The resume check in **3** checks the branch back out and picks up at the watch.
+
+To delay that: keep the reading you do proportionate to the ticket, and do not re-read files you have already changed — the edit tools error rather than silently failing, so a re-read to confirm a change landed buys nothing.
+
+**If the implementation is plainly too big for one context** — a ticket touching many packages, a migration across a whole surface — say so at the preflight rather than discovering it at 80%. That is what `/ship-spec` is for, and a ticket that large is usually a spec that was never split.

--- a/skills/ship-ticket/TRACKERS.md
+++ b/skills/ship-ticket/TRACKERS.md
@@ -1,0 +1,41 @@
+# Tracker operations
+
+Four operations drive a single-ticket run, whatever the tracker: **read the ticket**, **check its blockers are clear**, **record a PR on it**, **confirm it is done**. `docs/agents/issue-tracker.md` says which tracker this repo uses; follow that section. Anything it states beyond these operations — repo-specific labels, a project `create-pr` skill, PR conventions — wins over what's here.
+
+## GitHub (`gh`)
+
+- **Read** — `gh issue view <n> --json number,title,state,body,labels`. A ticket written by `/to-tickets` carries a `## Parent` section naming the spec issue; read that too. Where the repo uses sub-issues, `gh issue view <n> --json parent` is the exact answer.
+
+- **Blockers** — `gh issue view <n> --json blockedBy` returns each blocker with its state, so the ticket is ready when no blocker is `OPEN`:
+
+  ```bash
+  gh issue view <n> --json number,blockedBy \
+    --jq 'if [.blockedBy.nodes[]? | select(.state == "OPEN")] == [] then "ready" else "blocked" end'
+  ```
+
+  Prefer this over the REST `issue_dependencies_summary` — one call, and it names the blockers rather than counting them. Where a repo has no dependency links, parse the `Blocked by: #n` line in the body and check each referenced issue is closed. A blocker still open stops the run: report it and let the user decide whether to ship that one first (which is `/ship-spec`'s job, not this skill's).
+
+- **Resume check** — `gh issue view <n> --json closedByPullRequestsReferences` lists linked PRs on **open** issues too, so an open ticket with a PR there is a run to pick up rather than restart. Confirm with `gh pr view <pr> --json state,isDraft`.
+
+- **Record a PR** — the `Closes #<n>` line in the PR body creates that link. Add `gh issue edit <n> --add-assignee @me` so the ticket also reads as in flight to a human.
+
+- **Done** — the issue is closed, which `Closes #<n>` does on merge. If it is still open after the merge, close it yourself.
+
+## Local markdown
+
+Tickets are files under `.scratch/<feature-slug>/issues/<NN>-<slug>.md`.
+
+- **Read** — the file. Its `**Blocked by:**` line names the tickets it depends on.
+- **Blockers** — every ticket that line names has `**Status:** done`.
+- **Record a PR** — set `**Status:** in-progress` and append a `**PR:** <url>` line.
+- **Done** — set `**Status:** done`. Commit the status change with the merge, so the ledger and the code move together.
+
+The resume check is the `**PR:**` line on an `in-progress` ticket.
+
+## GitLab (`glab`)
+
+As GitHub, with `glab issue` / `glab mr` in place of `gh issue` / `gh pr`, and merge requests in place of pull requests. Blocking edges are GitLab's **blocked by** links (`glab api` on the issue links endpoint) or the same `Blocked by:` body line as a fallback.
+
+## Anything else
+
+`docs/agents/issue-tracker.md` records the workflow as prose. Map the four operations onto it before starting, and confirm the mapping with the user in the preflight.


### PR DESCRIPTION
This PR adds declarative agent skill management via agent-skills-nix, making 48+ skills available across all harnesses (Claude, OpenCode, Freebuff).

## What changed

Added agent-skills-nix as a flake input with a new Home Manager module that syncs skills to `~/.claude/skills`, `~/.agents/skills`, and `~/.config/opencode/skills`. Six skill sources are configured: local custom skills, mattpocock/skills (30 engineering/productivity skills), anthropics/skills (frontend-design), cursor/plugins (unslop), shadcn-ui/ui, and emilkowalski/skills (12 animation/design skills).

A custom activation script flattens nested skills for Claude, which only scans one level deep in its skills directory.

Also rewrote AGENTS.md and DOCS.md for better agent comprehension, and added a CLAUDE.md symlink.

## Why

Skills were previously managed manually via `npx skills` or copied into individual harness directories. This made them hard to maintain and impossible to share across harnesses. Declarative Nix management ensures all harnesses stay in sync and skills are version-pinned with the rest of the system.

## How to test

1. Run `AGENT_SKILLS_FORCE=1 just rebuild` to apply changes
2. Open Claude Code and check `/skills` — all 48+ skills should appear
3. Open OpenCode and check skills list — same skills should be available
4. Test a skill invocation (e.g., `/ship-ticket` or `/create-pr`)
