### PR TITLE
refactor(lib): consolidate builders and collapse trivial package modules

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# Nix System Configuration
+
+System configuration for multiple machines using Nix flakes, nix-darwin, NixOS, and Home-Manager. Hosts are defined in one place. Builders assemble the full system from host data, profiles, and platform modules.
+
+## Language
+
+**Host**:
+A named machine configuration (e.g. `Kyles-MacBook-Air`, `fedora`). Each host declares its system type, username, and which profiles to activate.
+_Avoid_: machine, node, box
+
+**Profile**:
+A named group of Home-Manager package modules (e.g. `cli`, `shell`, `git`). Profiles are imported by hosts to compose the set of installed programs.
+_Avoid_: bundle, collection, group
+
+**Builder**:
+A function in `lib/default.nix` that assembles a complete system configuration from host data, profiles, and platform modules. `mkDarwinSystem`, `mkNixosSystem`, and `homeConfigurations` are all builders.
+_Avoid_: factory, constructor, generator
+
+**specialArgs**:
+The per-host values (username, hostname, email, etc.) threaded into all NixOS, darwin, and Home-Manager modules via `extraSpecialArgs`. The single source of truth is `hosts/default.nix`.
+_Avoid_: args, context, config
+
+**Platform**:
+The OS-specific derivation choices controlled by `pkgs.stdenv.hostPlatform.isDarwin` / `isLinux`. Determines package variants, path prefixes, and feature flags.
+_Avoid_: system, arch, target
+
+**Custom package**:
+A derivation in `pkgs/custom/` not available in nixpkgs. Built via `fetchurl` or `fetchzip` and exposed through the overlay as `pkgs.custom.<name>`.
+\_Avoid\*: overlay package, local package
+
+**Common package**:
+A consolidated Home-Manager module that groups several simple program enables (e.g. `common-cli.nix` for the cli profile). One file replaces many single-line files.
+_Avoid_: trivial module, thin wrapper

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -7,13 +7,40 @@ let
   inherit (builtins) removeAttrs;
 
   # ── Host Metadata ───────────────────────────────────────────────────────────
-  # Single source of truth for all per-host values
+  # All per-host values live here
   hosts = import ../hosts;
 
   # Strip self from inputs for specialArgs (avoids infinite recursion)
   baseSpecialArgs = (removeAttrs inputs [ "self" ]) // {
     inherit inputs;
   };
+
+  # ── Host Field Extraction ───────────────────────────────────────────────────
+  # Destructure once — every builder and mkHomeShared reads from here
+  hostFields =
+    hostData:
+    let
+      inherit (hostData)
+        username
+        useremail
+        hostname
+        githubuser
+        githubname
+        gpgkeyid
+        stylixTheme
+        ;
+    in
+    {
+      inherit
+        username
+        useremail
+        hostname
+        githubuser
+        githubname
+        gpgkeyid
+        stylixTheme
+        ;
+    };
 
   # ── Home-Manager Shared Config ──────────────────────────────────────────────
   mkHomeShared =
@@ -47,7 +74,7 @@ let
       };
     };
 
-  # ── Home-Manager Profile Imports ──────────────────────────────────────────
+  # ── Home-Manager Profile Imports (NixOS / Darwin) ────────────────────────
   mkHomeImports =
     {
       username,
@@ -73,93 +100,68 @@ let
       };
     };
 
-  # ── Build a Darwin System ──────────────────────────────────────────────────
-  mkDarwinSystem =
-    hostName:
+  # ── Home-Manager Profile Imports (Standalone) ────────────────────────────
+  mkStandaloneImports =
+    { hostData }:
+    let
+      inherit (hostData) homeProfiles;
+      profileModule = name: ../modules/home/profiles + "/${name}.nix";
+    in
+    [
+      ../modules/home/base.nix
+
+      # Flake input home-manager modules
+      inputs.neru.homeManagerModules.default
+      inputs.nvs.homeManagerModules.default
+      inputs.uts.homeManagerModules.default
+      inputs.agent-skills.homeManagerModules.default
+    ]
+    ++ (map profileModule homeProfiles);
+
+  # ── Shared module sets ────────────────────────────────────────────────────
+  overlayModule = {
+    nixpkgs.overlays = [ inputs.self.overlays.default ];
+  };
+
+  stylixModules =
+    { type }:
+    let
+      stylix =
+        if type == "darwin" then
+          inputs.stylix.darwinModules.stylix
+        else if type == "nixos" then
+          inputs.stylix.nixosModules.stylix
+        else
+          inputs.stylix.homeModules.stylix;
+    in
+    [
+      stylix
+      ../modules/stylix/default.nix
+    ];
+
+  hmModule =
+    { type }:
+    if type == "darwin" then
+      inputs.home-manager.darwinModules.home-manager
+    else if type == "nixos" then
+      inputs.home-manager.nixosModules.home-manager
+    else
+      inputs.home-manager.lib.homeManagerConfiguration;
+
+  # ── System Builder ──────────────────────────────────────────────────────
+  mkSystem =
+    {
+      hostName,
+      type,
+      extraModules ? [ ],
+    }:
     let
       hostData = hosts.${hostName};
-      inherit (hostData)
-        system
-        username
-        useremail
-        hostname
-        githubuser
-        githubname
-        gpgkeyid
-        stylixTheme
-        safariWorkspaces
-        ;
-    in
-    inputs.darwin.lib.darwinSystem {
-      inherit system;
-      specialArgs = baseSpecialArgs // {
-        inherit
-          username
-          useremail
-          hostname
-          githubuser
-          githubname
-          gpgkeyid
-          stylixTheme
-          safariWorkspaces
-          ;
-      };
-      modules = [
-        ../modules/darwin/base.nix
-        ../modules/darwin/defaults.nix
-        ../modules/darwin/nix.nix
-        ../modules/darwin/karabiner.nix
-        ../modules/darwin/tailscale.nix
+      fields = hostFields hostData;
+      inherit (fields) username;
 
-        # Stylix
-        inputs.stylix.darwinModules.stylix
-        ../modules/stylix/default.nix
-
-        # Overlays
-        { nixpkgs.overlays = [ inputs.self.overlays.default ]; }
-
-        # Home-manager
-        inputs.home-manager.darwinModules.home-manager
-        (mkHomeShared {
-          inherit
-            username
-            useremail
-            hostname
-            githubuser
-            githubname
-            gpgkeyid
-            stylixTheme
-            ;
-        })
-        (mkHomeImports { inherit username hostData; })
-
-        # Determinate Nix
-        inputs.determinate.darwinModules.default
-      ]
-      ++ hostData.darwinModules or [ ];
-    };
-
-  # ── Build a NixOS System ───────────────────────────────────────────────────
-  mkNixosSystem =
-    hostName:
-    let
-      hostData = hosts.${hostName};
-      inherit (hostData)
-        system
-        username
-        useremail
-        hostname
-        githubuser
-        githubname
-        gpgkeyid
-        stylixTheme
-        ;
-      nixosProfile = ../profiles/nixos + "/${hostData.nixosProfile}.nix";
-    in
-    inputs.nixpkgs.lib.nixosSystem {
-      inherit system;
-      specialArgs = baseSpecialArgs // {
-        inherit
+      homeShared = mkHomeShared {
+        inherit (fields)
           username
           useremail
           hostname
@@ -168,35 +170,80 @@ let
           gpgkeyid
           stylixTheme
           ;
+        inherit (hostData) needsNixGL;
       };
-      modules = [
-        ../modules/nixos/base.nix
-        nixosProfile
 
-        # Overlays
-        { nixpkgs.overlays = [ inputs.self.overlays.default ]; }
+      homeImports = mkHomeImports {
+        inherit username hostData;
+      };
 
-        # Stylix
-        inputs.stylix.nixosModules.stylix
-        ../modules/stylix/default.nix
-
-        # Home-manager
-        inputs.home-manager.nixosModules.home-manager
-        (mkHomeShared {
-          inherit
-            username
-            useremail
-            hostname
-            githubuser
-            githubname
-            gpgkeyid
-            stylixTheme
-            ;
-        })
-        (mkHomeImports { inherit username hostData; })
-      ]
-      ++ hostData.nixosModules or [ ];
-    };
+      specialArgs =
+        baseSpecialArgs
+        // fields
+        // lib.optionalAttrs (hostData ? safariWorkspaces) {
+          inherit (hostData) safariWorkspaces;
+        }
+        // lib.optionalAttrs (hostData ? needsNixGL) {
+          inherit (hostData) needsNixGL;
+        };
+    in
+    if type == "darwin" then
+      inputs.darwin.lib.darwinSystem {
+        inherit (hostData) system;
+        inherit specialArgs;
+        modules = [
+          ../modules/darwin/base.nix
+          ../modules/darwin/defaults.nix
+          ../modules/darwin/nix.nix
+          ../modules/darwin/karabiner.nix
+          ../modules/darwin/tailscale.nix
+          overlayModule
+          (hmModule { type = "darwin"; })
+          homeShared
+          homeImports
+          inputs.determinate.darwinModules.default
+        ]
+        ++ (stylixModules { type = "darwin"; })
+        ++ extraModules
+        ++ (hostData.darwinModules or [ ]);
+      }
+    else if type == "nixos" then
+      let
+        nixosProfile = ../profiles/nixos + "/${hostData.nixosProfile}.nix";
+      in
+      inputs.nixpkgs.lib.nixosSystem {
+        inherit (hostData) system;
+        inherit specialArgs;
+        modules = [
+          ../modules/nixos/base.nix
+          nixosProfile
+          overlayModule
+          (hmModule { type = "nixos"; })
+          homeShared
+          homeImports
+        ]
+        ++ (stylixModules { type = "nixos"; })
+        ++ extraModules
+        ++ (hostData.nixosModules or [ ]);
+      }
+    else
+      # standalone home-manager
+      let
+        standaloneImports = mkStandaloneImports { inherit hostData; };
+      in
+      inputs.home-manager.lib.homeManagerConfiguration {
+        pkgs = import inputs.nixpkgs {
+          inherit (hostData) system;
+          config.allowUnfree = true;
+        };
+        extraSpecialArgs = specialArgs;
+        modules = [
+          overlayModule
+        ]
+        ++ (stylixModules { type = "home-manager"; })
+        ++ standaloneImports
+        ++ extraModules;
+      };
 
   # ── Filter hosts by type ──────────────────────────────────────────────────
   filterHosts = type: lib.filterAttrs (_: v: v.type == type) hosts;
@@ -206,48 +253,33 @@ in
 
   flake = {
     # Darwin configurations
-    darwinConfigurations = builtins.mapAttrs (name: _: mkDarwinSystem name) (filterHosts "darwin");
+    darwinConfigurations = builtins.mapAttrs (
+      name: _:
+      mkSystem {
+        hostName = name;
+        type = "darwin";
+      }
+    ) (filterHosts "darwin");
 
     # NixOS configurations
-    nixosConfigurations = builtins.mapAttrs (name: _: mkNixosSystem name) (filterHosts "nixos");
+    nixosConfigurations = builtins.mapAttrs (
+      name: _:
+      mkSystem {
+        hostName = name;
+        type = "nixos";
+      }
+    ) (filterHosts "nixos");
 
     # Standalone home-manager configurations
     homeConfigurations = builtins.mapAttrs (
-      _name: hostData:
-      inputs.home-manager.lib.homeManagerConfiguration {
-        pkgs = import inputs.nixpkgs {
-          inherit (hostData) system;
-          config.allowUnfree = true;
-        };
-        extraSpecialArgs = baseSpecialArgs // {
-          inherit (hostData)
-            username
-            useremail
-            hostname
-            githubuser
-            githubname
-            gpgkeyid
-            needsNixGL
-            stylixTheme
-            ;
-        };
-        modules = [
-          { nixpkgs.overlays = [ inputs.self.overlays.default ]; }
-          ../modules/home/base.nix
-          inputs.stylix.homeModules.stylix
-          ../modules/stylix/default.nix
-
-          # Flake input home-manager modules
-          inputs.neru.homeManagerModules.default
-          inputs.nvs.homeManagerModules.default
-          inputs.uts.homeManagerModules.default
-          inputs.agent-skills.homeManagerModules.default
-        ]
-        ++ (map (p: ../modules/home/profiles + "/${p}.nix") hostData.homeProfiles);
+      name: _:
+      mkSystem {
+        hostName = name;
+        type = "home-manager";
       }
     ) (filterHosts "home-manager");
 
-    # Reusable home-manager shared module (for external use)
+    # Home-manager shared module (exported for external use)
     homeModules.shared = mkHomeShared;
   };
 }

--- a/modules/home/packages/affinity.nix
+++ b/modules/home/packages/affinity.nix
@@ -1,5 +1,0 @@
-{ pkgs, ... }: {
-  home.packages = with pkgs; [
-    custom.affinity
-  ];
-}

--- a/modules/home/packages/ast-grep.nix
+++ b/modules/home/packages/ast-grep.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    ast-grep
-  ];
-}

--- a/modules/home/packages/btop.nix
+++ b/modules/home/packages/btop.nix
@@ -1,5 +1,0 @@
-_: {
-  programs.btop = {
-    enable = true;
-  };
-}

--- a/modules/home/packages/claude.nix
+++ b/modules/home/packages/claude.nix
@@ -1,5 +1,0 @@
-_: {
-  programs.claude-code = {
-    enable = true;
-  };
-}

--- a/modules/home/packages/cmd.nix
+++ b/modules/home/packages/cmd.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    custom.cmd
-  ];
-}

--- a/modules/home/packages/common-ai.nix
+++ b/modules/home/packages/common-ai.nix
@@ -1,0 +1,6 @@
+_: {
+  programs = {
+    opencode.enable = true;
+    claude-code.enable = true;
+  };
+}

--- a/modules/home/packages/common-cli.nix
+++ b/modules/home/packages/common-cli.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    ast-grep
+    custom.cmd
+    custom.diagnose
+    mkcert
+    devbox
+    rip2
+  ];
+
+  programs = {
+    btop.enable = true;
+    fd.enable = true;
+    jq.enable = true;
+    less.enable = true;
+  };
+}

--- a/modules/home/packages/common-macos.nix
+++ b/modules/home/packages/common-macos.nix
@@ -1,6 +1,9 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
+    custom.affinity
+    custom.mole
     orbstack
+    stripe-cli
   ];
 }

--- a/modules/home/packages/common-messaging.nix
+++ b/modules/home/packages/common-messaging.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rip2
+    discord
+    whatsapp-for-mac
   ];
 }

--- a/modules/home/packages/common-shell.nix
+++ b/modules/home/packages/common-shell.nix
@@ -1,0 +1,3 @@
+_: {
+  programs.zoxide.enable = true;
+}

--- a/modules/home/packages/devbox.nix
+++ b/modules/home/packages/devbox.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    devbox
-  ];
-}

--- a/modules/home/packages/diagnose.nix
+++ b/modules/home/packages/diagnose.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    custom.diagnose
-  ];
-}

--- a/modules/home/packages/discord.nix
+++ b/modules/home/packages/discord.nix
@@ -1,5 +1,0 @@
-_: {
-  programs.discord = {
-    enable = true;
-  };
-}

--- a/modules/home/packages/fd.nix
+++ b/modules/home/packages/fd.nix
@@ -1,5 +1,0 @@
-_: {
-  programs.fd = {
-    enable = true;
-  };
-}

--- a/modules/home/packages/jq.nix
+++ b/modules/home/packages/jq.nix
@@ -1,5 +1,0 @@
-_: {
-  programs.jq = {
-    enable = true;
-  };
-}

--- a/modules/home/packages/less.nix
+++ b/modules/home/packages/less.nix
@@ -1,5 +1,0 @@
-_: {
-  programs.less = {
-    enable = true;
-  };
-}

--- a/modules/home/packages/mkcert.nix
+++ b/modules/home/packages/mkcert.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    mkcert
-  ];
-}

--- a/modules/home/packages/mole.nix
+++ b/modules/home/packages/mole.nix
@@ -1,5 +1,0 @@
-{ pkgs, ... }: {
-  home.packages = with pkgs; [
-    custom.mole
-  ];
-}

--- a/modules/home/packages/opencode.nix
+++ b/modules/home/packages/opencode.nix
@@ -1,5 +1,0 @@
-_: {
-  programs.opencode = {
-    enable = true;
-  };
-}

--- a/modules/home/packages/stripe.nix
+++ b/modules/home/packages/stripe.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    stripe-cli
-  ];
-}

--- a/modules/home/packages/whatsapp.nix
+++ b/modules/home/packages/whatsapp.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    whatsapp-for-mac
-  ];
-}

--- a/modules/home/packages/zoxide.nix
+++ b/modules/home/packages/zoxide.nix
@@ -1,5 +1,0 @@
-_: {
-  programs.zoxide = {
-    enable = true;
-  };
-}

--- a/modules/home/profiles/ai.nix
+++ b/modules/home/profiles/ai.nix
@@ -1,8 +1,7 @@
 {
   imports = [
-    ../packages/opencode.nix
     ../packages/freebuff.nix
-    ../packages/claude.nix
     ../packages/skills.nix
+    ../packages/common-ai.nix
   ];
 }

--- a/modules/home/profiles/cli.nix
+++ b/modules/home/profiles/cli.nix
@@ -1,22 +1,12 @@
 {
   imports = [
-    ../packages/ast-grep.nix
     ../packages/bat.nix
-    ../packages/btop.nix
-    ../packages/cmd.nix
-    ../packages/devbox.nix
-    ../packages/diagnose.nix
     ../packages/direnv.nix
     ../packages/editorconfig.nix
     ../packages/eza.nix
-    ../packages/fd.nix
     ../packages/fzf.nix
-    ../packages/jq.nix
-    ../packages/less.nix
-    ../packages/mkcert.nix
     ../packages/neru.nix
-    ../packages/rip2.nix
     ../packages/ripgrep.nix
-    ../packages/uts.nix
+    ../packages/common-cli.nix
   ];
 }

--- a/modules/home/profiles/macos.nix
+++ b/modules/home/profiles/macos.nix
@@ -4,9 +4,6 @@
     ../packages/kanata.nix
     ../packages/mimi.nix
     ../packages/skhd.nix
-    ../packages/orbstack.nix
-    ../packages/affinity.nix
-    ../packages/mole.nix
-    ../packages/stripe.nix
+    ../packages/common-macos.nix
   ];
 }

--- a/modules/home/profiles/messaging.nix
+++ b/modules/home/profiles/messaging.nix
@@ -1,6 +1,5 @@
 {
   imports = [
-    ../packages/discord.nix
-    ../packages/whatsapp.nix
+    ../packages/common-messaging.nix
   ];
 }

--- a/modules/home/profiles/shell.nix
+++ b/modules/home/profiles/shell.nix
@@ -5,6 +5,6 @@
     ../packages/sesh.nix
     ../packages/starship.nix
     ../packages/tmux.nix
-    ../packages/zoxide.nix
+    ../packages/common-shell.nix
   ];
 }


### PR DESCRIPTION
This PR consolidates three duplicate builder functions into one and collapses 19 single-line package modules into 5 consolidated files.

## What changed

`lib/default.nix` now has a single `mkSystem { hostName, type }` function instead of `mkDarwinSystem`, `mkNixosSystem`, and a separate `homeConfigurations` block. specialArgs assembly, overlay injection, and Home-Manager wiring happen once.

Nineteen package modules that only contained `programs.X.enable = true` or `home.packages = [ pkgs.X ]` merge into `common-{profile}.nix` files. Deep modules (neru, ghostty, skills, git, fish, tmux) stay standalone.

Also adds `CONTEXT.md` with domain vocabulary (Host, Profile, Builder, specialArgs, Platform, Custom package, Common package).

## Why

Adding a new host field required editing three locations. The standalone HM path was missing the `mimi` module and had a broken `needsNixGL` inherit. Nineteen 5-line files added navigation overhead with no depth.

## How to test

```bash
nix eval '.#darwinConfigurations.Kyles-MacBook-Air.system' --impure
nix eval '.#homeConfigurations.fedora.config.home.username' --impure
just check
```