### PR TITLE
feat(skills): add caveman skill for token-efficient communication

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -128,6 +128,22 @@
         "type": "github"
       }
     },
+    "caveman-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787282775,
+        "narHash": "sha256-FagkzOnjW9tqeaAK8NX1X8REsjWRRMqfrvhByEtrAXM=",
+        "owner": "JuliusBrussee",
+        "repo": "caveman",
+        "rev": "2f49f0e1a352aa810e70056b7930aeb0b3d219b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JuliusBrussee",
+        "repo": "caveman",
+        "type": "github"
+      }
+    },
     "cursor-plugins": {
       "flake": false,
       "locked": {
@@ -500,12 +516,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1787312936,
-        "narHash": "sha256-JBOwPoPNJMwpPnlyf4E2l2sT1Pv+DYXyupdWlsR12/k=",
-        "rev": "4ee665ca28657b2bfab8af5e2b1a8362ef42d85e",
-        "revCount": 1296,
+        "lastModified": 1787393920,
+        "narHash": "sha256-rZ7r/Wx+XBFwp8Re2FonS8VvFKRds+tQTg75vAcUtlY=",
+        "rev": "36989b70440771d5eb8b33e0df577124288163fc",
+        "revCount": 1297,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/y3owk1n/neru/0.1.1296%2Brev-4ee665ca28657b2bfab8af5e2b1a8362ef42d85e/01a02427-e5e6-7c40-a98f-7d5ba65d2c7c/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/y3owk1n/neru/0.1.1297%2Brev-36989b70440771d5eb8b33e0df577124288163fc/01a028fb-79a1-7c20-ae19-8500edcbee88/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -741,6 +757,7 @@
       "inputs": {
         "agent-skills": "agent-skills",
         "anthropics-skills": "anthropics-skills",
+        "caveman-skills": "caveman-skills",
         "cursor-plugins": "cursor-plugins",
         "darwin": "darwin",
         "determinate": "determinate",

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,10 @@
       url = "github:emilkowalski/skills";
       flake = false;
     };
+    caveman-skills = {
+      url = "github:JuliusBrussee/caveman";
+      flake = false;
+    };
 
     # Development Tools & Infrastructure
     flake-parts.url = "https://flakehub.com/f/hercules-ci/flake-parts/0.1";

--- a/modules/home/packages/skills.nix
+++ b/modules/home/packages/skills.nix
@@ -55,6 +55,13 @@
         subdir = "skills";
         idPrefix = "emil";
       };
+
+      # Caveman skills (compressed communication)
+      caveman = {
+        input = "caveman-skills";
+        subdir = "skills";
+        idPrefix = "julius";
+      };
     };
 
     # Enable specific skills from the catalog
@@ -65,6 +72,9 @@
       "add-skill"
       "create-pr"
       "find-skills"
+
+      # Caveman skills
+      "julius/caveman"
 
       # Cursor plugins
       "cursor/unslop"


### PR DESCRIPTION
This PR adds the caveman skill from JuliusBrussee/caveman for ultra-compressed communication mode.

## What changed

Added the caveman skill that cuts output tokens by ~65% by speaking in caveman-speak while keeping full technical accuracy. The skill supports multiple intensity levels: lite, full, ultra, and wenyan variants.

## Why

Token efficiency matters for cost and speed. The caveman skill provides a structured way to reduce output verbosity while maintaining technical substance.

## How to test

1. Run `just rebuild Kyles-MacBook-Air`
2. In Claude Code, say "caveman mode" or use `/caveman`
3. Verify responses are shorter but technically accurate