### PR TITLE
refactor(ai): optimize claude-code context for token efficiency

### DIFF
--- a/modules/home/packages/common-ai.nix
+++ b/modules/home/packages/common-ai.nix
@@ -2,5 +2,43 @@ _: {
   programs = {
     opencode.enable = true;
     claude-code.enable = true;
+    claude-code.context = ''
+      ## Approach
+
+      - Read files once. Re-read only when changed.
+      - Write tight code: direct, minimal, one purpose per abstraction.
+      - Solve only what was asked. No speculative additions.
+      - Change only what's needed. Leave untouched code untouched.
+      - Verify APIs, versions, flags, and package names from source.
+      - Surface errors with full context. No silent catches.
+      - Code first, explanation after only when non-obvious.
+      - ASCII punctuation only. No emojis, em-dashes, hyphens, or decorative Unicode.
+
+      ## Review
+
+      - One pass: state the bug, show the fix, stop.
+
+      ## Workflow
+
+      - Test after writing. Fix before moving on.
+      - Verify output matches expected format.
+      - Never declare done without running the code.
+
+      ## Search Protocol
+
+      - Public URLs → ctx_fetch_and_index(url), then ctx_search.
+      - Inline WebFetch only for private/authenticated URLs.
+
+      ## Model Selection
+
+      **opus-5:** Architecture, security reviews, 5+ file refactors, requirements.
+      **sonnet-5:** Standard coding, CRUD, config edits, CI triage.
+      **haiku-4.5:** Code lookup, single-function questions, diff review.
+
+      ## Effort
+
+      - `xhigh` budget: architectural decisions only.
+      - Default budget: CRUD and routine tasks.
+    '';
   };
 }


### PR DESCRIPTION
This PR optimizes the global claude-code.context in common-ai.nix for token efficiency.

## What changed

Rewrote the claude-code.context with tighter rules, positive framing, and stronger leading words. Reduced from ~150 tokens to ~130 tokens while preserving all behavioral guidance.

## Why

Every token in the global context costs on every turn. Tighter context means lower input cost across all sessions and projects.

## How to test

1. Rebuild: `just rebuild <host>`
2. Open a Claude Code session
3. Verify the context loads correctly by checking `/cost` output
4. Test a coding task to confirm behavioral rules apply

## Changes summary

- Merged Approach, Coding, Review, Workflow into 3 tight sections
- Removed negation patterns, used positive framing
- Strong leading words: tight code, one pass, one purpose
- Pruned no-ops: thorough in reasoning, skip 100KB
- Removed Advisor-Tool reference (unused beta feature)
- Kept Search Protocol, Model Selection, Effort as universal rules