### PR TITLE
docs(skills): require conventional commit format for PR titles

### DIFF
--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -11,6 +11,7 @@ description: "Commit changes and open a pull request."
 - **Never push to `main`.** New branch always.
 - **Explicit staging only.** No `git add -A` or `git add .` — stage paths individually.
 - **One change per commit, one change per PR.**
+- **PR title is a conventional commit subject.** PRs land as squash merges, so the title becomes the commit message on `main`.
 
 ## Steps
 
@@ -20,10 +21,12 @@ description: "Commit changes and open a pull request."
 4. **Commit.** Compose the message, then grep it for attribution leaks (`claude|anthropic|co-authored|generated with`) before committing.
 5. **Check for a template.** `cat .github/pull_request_template.md 2>/dev/null`
 6. **Write PR body.** Compose the body using the template below. Open with `This PR <verb> ...`.
-7. **Push and open.** `git push -u origin <branch> && gh pr create --title "<title>" --body "<body>"`
+7. **Push and open.** `git push -u origin <branch> && gh pr create --title "<type>(<scope>): <subject>" --body "<body>"`
 8. **Watch CI.** `gh pr checks --watch`
 
-## Commit format
+## Commit and PR title format
+
+Both use the same shape:
 
 `<type>(<scope>): <subject>`
 
@@ -34,7 +37,9 @@ Write the subject for a **user**, not the diff:
 - `fix(auth): handle expired tokens gracefully` ✓
 - `fix: update auth.go` ✗
 
-Body: explain _why_ and behaviour change, wrap at 72 chars. `Closes #123` when fixing an issue.
+For a single-commit PR, reuse the commit subject as the title. For a multi-commit PR, write a subject that covers the whole branch rather than copying the last commit.
+
+Commit body: explain _why_ and behaviour change, wrap at 72 chars. `Closes #123` when fixing an issue.
 
 ## PR body (no template)
 
@@ -63,4 +68,4 @@ Config/command changes: name them exactly as typed, note defaults, say whether e
 
 ## Completion
 
-Done when: checks are green, the PR is open with a title and body written for a reader, and no commit or PR text mentions Claude, Anthropic, or AI. Checkable: `gh pr checks` passes, and `gh pr view --json title,body` piped through `grep -iE 'claude|anthropic|co-authored|generated with'` returns nothing.
+Done when: checks are green, the PR is open with a conventional-commit title and a body written for a reader, and no commit or PR text mentions Claude, Anthropic, or AI. Checkable: `gh pr checks` passes, `gh pr view --json title -q .title` matches `^(feat|fix|perf|revert|docs|refactor|test|chore|ci|build|style)(\(.+\))?!?: .+`, and `gh pr view --json title,body` piped through `grep -iE 'claude|anthropic|co-authored|generated with'` returns nothing.

--- a/skills/ship/SUBAGENT-BRIEF.md
+++ b/skills/ship/SUBAGENT-BRIEF.md
@@ -32,7 +32,7 @@ Spec: <spec issue number>
 
 6. **Regenerate whatever your change invalidated**: <the repo's regeneration commands>. A checked-in generated artefact nobody regenerated is the one failure that is certain rather than probable, and the one CI cannot tell you anything new about.
 
-7. `git fetch origin && git rebase origin/main`, run the **fast checks only** — <fast check commands> — plus, by name, the test files your change touched. **Not the full gate.** Then commit and open the PR with <the `pr` skill | `gh pr create`>. The body states what changed for a user and links the ticket (`Closes #<n>`).
+7. `git fetch origin && git rebase origin/main`, run the **fast checks only** — <fast check commands> — plus, by name, the test files your change touched. **Not the full gate.** Then commit and open the PR with <the `pr` skill | `gh pr create`>. The title is a conventional commit subject (`<type>(<scope>): <subject>`) because PRs land as squash merges. The body states what changed for a user and links the ticket (`Closes #<n>`).
 
 **CI is the gate, and running it twice does not make it truer.** The suite takes minutes; CI runs the identical command on the identical commit within minutes of the push, and the orchestrator is already watching. A local full run buys a signal you are about to be handed for free, at the price of the slowest step in the ticket. The fast checks and the regeneration cover what CI would tell you _late_ — a type error, a lint finding, a stale artefact. What they do not cover is behaviour, and behaviour is what CI is for.
 


### PR DESCRIPTION
This PR makes the `pr` skill require a conventional commit subject for the PR title, not just for the commit message.

## What changed

`skills/pr/SKILL.md` gains a guardrail stating the PR title is a conventional commit subject, and step 7 spells the shape into the command it runs: `gh pr create --title "<type>(<scope>): <subject>"`. The section previously named `## Commit format` is now `## Commit and PR title format`, so the type list and the "write the subject for a user, not the diff" examples apply to both. It also answers the case the rule alone leaves open: a single-commit PR reuses its commit subject, a multi-commit PR gets a subject covering the whole branch rather than a copy of the last commit. The completion criterion is now checkable rather than a matter of judgement — the title must match `^(feat|fix|perf|revert|docs|refactor|test|chore|ci|build|style)(\(.+\))?!?: .+`.

`skills/ship/SUBAGENT-BRIEF.md` step 7 carries the same requirement. That step lets a subagent open the PR with either the `pr` skill or a raw `gh pr create`, and the raw path would otherwise have skipped the convention entirely.

## Why

PRs in this repo land as squash merges, so the PR title becomes the commit message on `main`. Constraining only the commit subject left the title free-form, and every squashed branch could put a non-conventional subject into the history.

## How to test

Read `skills/pr/SKILL.md` and confirm the title requirement appears in the guardrails, in step 7, and in the completion criterion. This PR's own title is the first case the rule applies to:

```
gh pr view --json title -q .title | grep -E '^(feat|fix|perf|revert|docs|refactor|test|chore|ci|build|style)(\(.+\))?!?: .+'
```

Issue titles in `skills/spec/SKILL.md` (`Spec: <feature>`, `<NN>: <title>`) are deliberately unchanged — they are GitHub issues, never squashed into a commit.
